### PR TITLE
Symlink instead of copy mysql connector. puppetlabs/mysql 5 compatibility

### DIFF
--- a/manifests/datasource/mysql.pp
+++ b/manifests/datasource/mysql.pp
@@ -22,8 +22,8 @@ class keycloak::datasource::mysql (
     mode   => '0755',
   }
   file { "${$module_dir}/mysql-connector-java.jar":
-    ensure  => 'file',
-    source  => $jar_source,
+    ensure  => 'link',
+    target  => $jar_source,
     owner   => $keycloak::user,
     group   => $keycloak::group,
     mode    => '0644',


### PR DESCRIPTION
At least on Debian 9 with puppetlabs/mysql 5.2.1, /usr/share/java/mysql-connector-java.jar is a local symlink to mysql-connector-java-5.1.42.jar, so if you copy it verbatim to another location it ends broken.

I think changing the policy from copying to symlinking has no side effects and makes it run smooth.