### PR TITLE
Add SAML support to keycloak_protocol_mapper and keycloak::client_template

### DIFF
--- a/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
@@ -35,14 +35,25 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
           protocol_mapper[:type] = d['protocolMapper']
           protocol_mapper[:consent_required] = d['consentRequired'].to_s.to_sym
           protocol_mapper[:consent_text] = d['consentText']
-          if protocol_mapper[:type] == 'oidc-usermodel-property-mapper'
+          if protocol_mapper[:type] == 'oidc-usermodel-property-mapper' or protocol_mapper[:type] == 'saml-user-property-mapper'
             protocol_mapper[:user_attribute] = d['config']['user.attribute']
+          end
+          if protocol_mapper[:type] == 'oidc-usermodel-property-mapper'
             protocol_mapper[:claim_name] = d['config']['claim.name']
             protocol_mapper[:json_type_label] = d['config']['jsonType.label']
           end
-          protocol_mapper[:id_token_claim] = d['config']['id.token.claim']
-          protocol_mapper[:access_token_claim] = d['config']['access.token.claim']
-          protocol_mapper[:userinfo_token_claim] = d['config']['userinfo.token.claim']
+          if protocol_mapper[:type] == 'saml-user-property-mapper'
+            protocol_mapper[:friendly_name] = d['config']['friendly.name']
+            protocol_mapper[:attribute_name] = d['config']['attribute.name']
+          end
+          if protocol_mapper[:protocol] == 'openid-connect'
+            protocol_mapper[:id_token_claim] = d['config']['id.token.claim']
+            protocol_mapper[:access_token_claim] = d['config']['access.token.claim']
+            protocol_mapper[:userinfo_token_claim] = d['config']['userinfo.token.claim']
+          end
+          if protocol_mapper[:protocol] == 'saml'
+            protocol_mapper[:attribute_nameformat] = d['config']['attribute.nameformat']
+          end
           protocol_mappers << new(protocol_mapper)
         end
       end
@@ -72,17 +83,28 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
     data[:name] = resource[:resource_name]
     data[:protocol] = resource[:protocol]
     data[:protocolMapper] = resource[:type]
-    data[:consentRequired] = resource[:consent_required] if resource[:consent_required]
+    data[:consentRequired] = resource[:consent_required]
     data[:consentText] = resource[:consent_text] if resource[:consent_text]
     data[:config] = {}
-    if resource[:type] == 'oidc-usermodel-property-mapper'
+    if resource[:type] == 'oidc-usermodel-property-mapper' or resource[:type] == 'saml-user-property-mapper'
       data[:config][:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
+    end
+    if resource[:type] == 'oidc-usermodel-property-mapper'
       data[:config][:'claim.name'] = resource[:claim_name] if resource[:claim_name]
       data[:config][:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
     end
-    data[:config][:'id.token.claim'] = resource[:id_token_claim] if resource[:id_token_claim]
-    data[:config][:'access.token.claim'] = resource[:access_token_claim] if resource[:access_token_claim]
-    data[:config][:'userinfo.token.claim'] = resource[:userinfo_token_claim] if resource[:userinfo_token_claim]
+    if resource[:type] == 'saml-user-property-mapper'
+      data[:config][:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]
+      data[:config][:'attribute.name'] = resource[:attribute_name] if resource[:attribute_name]
+    end
+    if resource[:protocol] == 'openid-connect'
+      data[:config][:'id.token.claim'] = resource[:id_token_claim] if resource[:id_token_claim]
+      data[:config][:'access.token.claim'] = resource[:access_token_claim] if resource[:access_token_claim]
+      data[:config][:'userinfo.token.claim'] = resource[:userinfo_token_claim] if resource[:userinfo_token_claim]
+    end
+    if resource[:protocol] == 'saml'
+      data[:config][:'attribute.nameformat'] = resource[:attribute_nameformat] if resource[:attribute_nameformat]
+    end
 
     t = Tempfile.new('keycloak_protocol_mapper')
     t.write(JSON.pretty_generate(data))
@@ -134,17 +156,28 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
       data[:name] = resource[:resource_name]
       data[:protocol] = resource[:protocol]
       data[:protocolMapper] = resource[:type]
-      data[:consentRequired] = resource[:consent_required] if resource[:consent_required]
+      data[:consentRequired] = resource[:consent_required]
       data[:consentText] = resource[:consent_text] if resource[:consent_text]
       config = {}
-      if resource[:type] == 'oidc-usermodel-property-mapper'
+      if resource[:type] == 'oidc-usermodel-property-mapper' or resource[:type] == 'saml-user-property-mapper'
         config[:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
+      end
+      if resource[:type] == 'oidc-usermodel-property-mapper'
         config[:'claim.name'] = resource[:claim_name] if resource[:claim_name]
         config[:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
       end
-      config[:'id.token.claim'] = resource[:id_token_claim] if resource[:id_token_claim]
-      config[:'access.token.claim'] = resource[:access_token_claim] if resource[:access_token_claim]
-      config[:'userinfo.token.claim'] = resource[:userinfo_token_claim] if resource[:userinfo_token_claim]
+      if resource[:type] == 'saml-user-property-mapper'
+        config[:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]
+        config[:'attribute.name'] = resource[:attribute_name] if resource[:attribute_name]
+      end
+      if resource[:protocol] == 'openid-connect'
+        config[:'id.token.claim'] = resource[:id_token_claim] if resource[:id_token_claim]
+        config[:'access.token.claim'] = resource[:access_token_claim] if resource[:access_token_claim]
+        config[:'userinfo.token.claim'] = resource[:userinfo_token_claim] if resource[:userinfo_token_claim]
+      end
+      if resource[:protocol] == 'saml'
+        config[:'attribute.nameformat'] = resource[:attribute_nameformat] if resource[:attribute_nameformat]
+      end
       data[:config] = config unless config.empty?
 
       t = Tempfile.new('keycloak_protocol_mapper')

--- a/manifests/client_template.pp
+++ b/manifests/client_template.pp
@@ -2,7 +2,7 @@
 define keycloak::client_template (
   String $realm,
   String $resource_name = $name,
-  Enum['openid-connect'] $protocol = 'openid-connect',
+  Enum['openid-connect', 'saml'] $protocol = 'openid-connect',
   Boolean $full_scope_allowed = true,
 ) {
 
@@ -15,34 +15,68 @@ define keycloak::client_template (
     full_scope_allowed => $full_scope_allowed,
   }
 
-  keycloak_protocol_mapper { "email for ${name} on ${realm}":
-    consent_text   => '${email}', #lint:ignore:single_quote_string_with_variables
-    claim_name     => 'email',
-    user_attribute => 'email',
+  if $protocol == 'openid-connect' {
+    keycloak_protocol_mapper { "email for ${name} on ${realm}":
+      consent_text   => '${email}', #lint:ignore:single_quote_string_with_variables
+      claim_name     => 'email',
+      user_attribute => 'email',
+    }
+
+    keycloak_protocol_mapper { "username for ${name} on ${realm}":
+      consent_text   => '${username}', #lint:ignore:single_quote_string_with_variables
+      claim_name     => 'preferred_username',
+      user_attribute => 'username',
+    }
+
+    keycloak_protocol_mapper { "full name for ${name} on ${realm}":
+      consent_text         => '${fullName}', #lint:ignore:single_quote_string_with_variables
+      type                 => 'oidc-full-name-mapper',
+      userinfo_token_claim => false,
+    }
+
+    keycloak_protocol_mapper { "family name for ${name} on ${realm}":
+      consent_text   => '${familyName}', #lint:ignore:single_quote_string_with_variables
+      claim_name     => 'family_name',
+      user_attribute => 'lastName',
+    }
+
+    keycloak_protocol_mapper { "given name for ${name} on ${realm}":
+      consent_text   => '${givenName}', #lint:ignore:single_quote_string_with_variables
+      claim_name     => 'given_name',
+      user_attribute => 'firstName',
+    }
   }
 
-  keycloak_protocol_mapper { "username for ${name} on ${realm}":
-    consent_text   => '${username}', #lint:ignore:single_quote_string_with_variables
-    claim_name     => 'preferred_username',
-    user_attribute => 'username',
-  }
+  if $protocol == 'saml' {
+    keycloak_protocol_mapper { "X500 email for ${name} on ${realm}":
+      protocol             => $protocol,
+      type                 => 'saml-user-property-mapper',
+      consent_text         => "\${email}",
+      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      user_attribute       => 'email',
+      friendly_name        => 'email',
+      attribute_name       => 'urn:oid:1.2.840.113549.1.9.1'
+    }
 
-  keycloak_protocol_mapper { "full name for ${name} on ${realm}":
-    consent_text         => '${fullName}', #lint:ignore:single_quote_string_with_variables
-    type                 => 'oidc-full-name-mapper',
-    userinfo_token_claim => false,
-  }
+    keycloak_protocol_mapper { "X500 givenName for ${name} on ${realm}":
+      protocol             => $protocol,
+      type                 => 'saml-user-property-mapper',
+      consent_text         => "\${givenName}",
+      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      user_attribute       => 'firstName',
+      friendly_name        => 'givenName',
+      attribute_name       => 'urn:oid:2.5.4.42'
+    }
 
-  keycloak_protocol_mapper { "family name for ${name} on ${realm}":
-    consent_text   => '${familyName}', #lint:ignore:single_quote_string_with_variables
-    claim_name     => 'family_name',
-    user_attribute => 'lastName',
-  }
-
-  keycloak_protocol_mapper { "given name for ${name} on ${realm}":
-    consent_text   => '${givenName}', #lint:ignore:single_quote_string_with_variables
-    claim_name     => 'given_name',
-    user_attribute => 'firstName',
+    keycloak_protocol_mapper { "X500 surname for ${name} on ${realm}":
+      protocol             => $protocol,
+      type                 => 'saml-user-property-mapper',
+      consent_text         => "\${familyName}",
+      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      user_attribute       => 'lastName',
+      friendly_name        => 'surname',
+      attribute_name       => 'urn:oid:2.5.4.4'
+    }
   }
 
 }

--- a/spec/acceptance/4_client_template_spec.rb
+++ b/spec/acceptance/4_client_template_spec.rb
@@ -37,4 +37,23 @@ describe 'keycloak::client-template define:' do
       apply_manifest(pp, :catch_changes => true)
     end
   end
+
+  context 'creates saml client-template' do
+    it 'should run successfully' do
+      pp =<<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_realm { 'test': ensure => 'present' }
+      keycloak::client_template { 'saml-clients':
+        realm    => 'test',
+        protocol => 'saml',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
 end

--- a/spec/acceptance/6_protocol_mapper_spec.rb
+++ b/spec/acceptance/6_protocol_mapper_spec.rb
@@ -57,4 +57,39 @@ describe 'keycloak_protocol_mapper type:' do
       apply_manifest(pp, :catch_changes => true)
     end
   end
+
+  context 'creates saml protocol_mapper' do
+    it 'should run successfully' do
+      pp =<<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_realm { 'test': ensure => 'present' }
+      keycloak_client_template { 'saml on test':
+        ensure => 'present',
+        protocol => 'saml',
+      }
+      keycloak_protocol_mapper { "email for saml on test":
+        protocol       => 'saml',
+        type           => 'saml-user-property-mapper',
+        consent_text   => '${email}',
+        user_attribute => 'email',
+        friendly_name  => 'email',
+        attribute_name => 'email',
+      }
+      keycloak_protocol_mapper { "firstName for saml on test":
+        protocol       => 'saml',
+        type           => 'saml-user-property-mapper',
+        consent_text   => '${givenName}',
+        user_attribute => 'firstName',
+        friendly_name  => 'firstName',
+        attribute_name => 'firstName',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+  end
 end

--- a/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
@@ -63,6 +63,11 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
     expect(@protocol_mapper[:type]).to eq('oidc-full-name-mapper')
   end
 
+  it 'should allow valid type' do
+    @protocol_mapper[:type] = 'saml-user-property-mapper'
+    expect(@protocol_mapper[:type]).to eq('saml-user-property-mapper')
+  end
+
   it 'should not allow invalid type' do
     expect {
       @protocol_mapper[:type] = 'foo'
@@ -100,6 +105,26 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
     expect(component[:json_type_label]).to eq('String')
   end
 
+  it 'should have friendly_name as nil' do
+    expect(@protocol_mapper[:friendly_name]).to be_nil
+  end
+
+  it 'should allow valid friendly_name' do
+    @protocol_mapper[:type] = 'saml-user-property-mapper'
+    @protocol_mapper[:friendly_name] = 'email'
+    expect(@protocol_mapper[:friendly_name]).to eq('email')
+  end
+
+  it 'should have attribute_name as nil' do
+    expect(@protocol_mapper[:attribute_name]).to be_nil
+  end
+
+  it 'should allow valid attribute_name' do
+    @protocol_mapper[:type] = 'saml-user-property-mapper'
+    @protocol_mapper[:attribute_name] = 'email'
+    expect(@protocol_mapper[:attribute_name]).to eq('email')
+  end
+
   # Test boolean properties
   [
     :consent_required,
@@ -124,6 +149,11 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
         @protocol_mapper[p] = 'foo'
       }.to raise_error
     end
+  end
+
+  it 'should accept value for attribute_nameformat' do
+    @protocol_mapper[:attribute_nameformat] = 'Basic'
+    expect(@protocol_mapper[:attribute_nameformat]).to eq('Basic')
   end
 
   it 'should autorequire keycloak_conn_validator' do


### PR DESCRIPTION
Add several properties to keycloak_protocol_mapper that are specific to SAML clients.
Add the builtin SAML client protocol mappers to keycloak::client_template when protocol=saml