### PR TITLE
Allow keycloak_protocol_mapper attribute_nameformat to be simpler values

### DIFF
--- a/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
@@ -5,6 +5,22 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
 
   mk_resource_methods
 
+  def self.attribute_nameformat_map
+    {
+      :uri => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      :basic => 'Basic',
+      :unspecified => 'Unspecified',
+    }
+  end
+
+  def self.get_attribute_nameformat(v)
+    attribute_nameformat_map[v.to_sym]
+  end
+
+  def self.get_attribute_nameformat_reverse(v)
+    attribute_nameformat_map.invert[v]
+  end
+
   def self.instances
     protocol_mappers = []
 
@@ -52,7 +68,7 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
           end
           if protocol_mapper[:protocol] == 'saml'
             protocol_mapper[:attribute_name] = d['config']['attribute.name']
-            protocol_mapper[:attribute_nameformat] = d['config']['attribute.nameformat']
+            protocol_mapper[:attribute_nameformat] = get_attribute_nameformat_reverse(d['config']['attribute.nameformat'])
           end
           if protocol_mapper[:type] == 'saml-role-list-mapper'
             protocol_mapper[:single] = d['config']['single'].to_s.to_sym
@@ -106,7 +122,7 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
     end
     if resource[:protocol] == 'saml'
       data[:config][:'attribute.name'] = resource[:attribute_name] if resource[:attribute_name]
-      data[:config][:'attribute.nameformat'] = resource[:attribute_nameformat] if resource[:attribute_nameformat]
+      data[:config][:'attribute.nameformat'] = self.class.get_attribute_nameformat(resource[:attribute_nameformat]) if resource[:attribute_nameformat]
     end
     if resource[:type] == 'saml-role-list-mapper'
       data[:config][:single] = resource[:single].to_s if resource[:single]
@@ -182,7 +198,7 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, :parent => Puppet::
       end
       if resource[:protocol] == 'saml'
         config[:'attribute.name'] = resource[:attribute_name] if resource[:attribute_name]
-        config[:'attribute.nameformat'] = resource[:attribute_nameformat] if resource[:attribute_nameformat]
+        config[:'attribute.nameformat'] = self.class.get_attribute_nameformat(resource[:attribute_nameformat]) if resource[:attribute_nameformat]
       end
       if resource[:type] == 'saml-role-list-mapper'
         config[:single] = resource[:single].to_s if resource[:single]

--- a/lib/puppet/type/keycloak_protocol_mapper.rb
+++ b/lib/puppet/type/keycloak_protocol_mapper.rb
@@ -148,6 +148,14 @@ Puppet::Type.newtype(:keycloak_protocol_mapper) do
 
   newproperty(:attribute_nameformat) do
     desc "attribute.nameformat"
+    validate do |v|
+      if ! [:basic, :uri, :unspecified].include?(v.downcase.to_sym)
+        raise ArgumentError, "attribute_nameformat must be one of basic, uri, or unspecified"
+      end
+    end
+    munge do |v|
+      v.downcase.to_sym
+    end
   end
 
   newproperty(:single, :boolean => true) do

--- a/manifests/client_template.pp
+++ b/manifests/client_template.pp
@@ -52,7 +52,7 @@ define keycloak::client_template (
       protocol             => $protocol,
       type                 => 'saml-user-property-mapper',
       consent_text         => "\${username}",
-      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      attribute_nameformat => 'uri',
       user_attribute       => 'username',
       friendly_name        => 'username',
       attribute_name       => 'urn:oid:0.9.2342.19200300.100.1.1'
@@ -62,7 +62,7 @@ define keycloak::client_template (
       protocol             => $protocol,
       type                 => 'saml-user-property-mapper',
       consent_text         => "\${email}",
-      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      attribute_nameformat => 'uri',
       user_attribute       => 'email',
       friendly_name        => 'email',
       attribute_name       => 'urn:oid:1.2.840.113549.1.9.1'
@@ -72,7 +72,7 @@ define keycloak::client_template (
       protocol             => $protocol,
       type                 => 'saml-user-property-mapper',
       consent_text         => "\${givenName}",
-      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      attribute_nameformat => 'uri',
       user_attribute       => 'firstName',
       friendly_name        => 'givenName',
       attribute_name       => 'urn:oid:2.5.4.42'
@@ -82,7 +82,7 @@ define keycloak::client_template (
       protocol             => $protocol,
       type                 => 'saml-user-property-mapper',
       consent_text         => "\${familyName}",
-      attribute_nameformat => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+      attribute_nameformat => 'uri',
       user_attribute       => 'lastName',
       friendly_name        => 'surname',
       attribute_name       => 'urn:oid:2.5.4.4'
@@ -93,7 +93,7 @@ define keycloak::client_template (
       type                 => 'saml-role-list-mapper',
       consent_required     => false,
       single               => false,
-      attribute_nameformat => 'Basic',
+      attribute_nameformat => 'basic',
       attribute_name       => 'Role',
     }
   }

--- a/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
@@ -153,7 +153,15 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
 
   it 'should accept value for attribute_nameformat' do
     @protocol_mapper[:attribute_nameformat] = 'Basic'
-    expect(@protocol_mapper[:attribute_nameformat]).to eq('Basic')
+    expect(@protocol_mapper[:attribute_nameformat]).to eq(:basic)
+    @protocol_mapper[:attribute_nameformat] = 'uri'
+    expect(@protocol_mapper[:attribute_nameformat]).to eq(:uri)
+  end
+
+  it 'should not accept invalid value for attribute_nameformat' do
+    expect {
+      @protocol_mapper[:attribute_nameformat] = 'foo'
+    }.to raise_error
   end
 
   it 'should accept value for single' do


### PR DESCRIPTION
A mapping will take place from simple values to the actual values passed to keycloak