### PR TITLE
Fix title patterns that use procs are not supported

### DIFF
--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -160,15 +160,15 @@ Puppet::Type.newtype(:keycloak_client) do
       [
         /^((\S+) on (\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :client_id, lambda{|x| x} ],
-          [ :realm, lambda{|x| x} ],
+          [:name],
+          [:client_id],
+          [:realm],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [:name],
         ],
       ],
     ]

--- a/lib/puppet/type/keycloak_client_template.rb
+++ b/lib/puppet/type/keycloak_client_template.rb
@@ -69,15 +69,15 @@ Puppet::Type.newtype(:keycloak_client_template) do
       [
         /^((\S+) on (\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :resource_name, lambda{|x| x} ],
-          [ :realm, lambda{|x| x} ],
+          [:name],
+          [:resource_name],
+          [:realm],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [:name],
         ],
       ],
     ]

--- a/lib/puppet/type/keycloak_ldap_mapper.rb
+++ b/lib/puppet/type/keycloak_ldap_mapper.rb
@@ -130,16 +130,16 @@ Puppet::Type.newtype(:keycloak_ldap_mapper) do
       [
         /^((.+) for (\S+) on (\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :resource_name, lambda{|x| x} ],
-          [ :ldap, lambda{|x| x} ],
-          [ :realm, lambda{|x| x} ],
+          [:name],
+          [:resource_name],
+          [:ldap],
+          [:realm],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [:name],
         ],
       ],
     ]

--- a/lib/puppet/type/keycloak_ldap_user_provider.rb
+++ b/lib/puppet/type/keycloak_ldap_user_provider.rb
@@ -146,15 +146,15 @@ Puppet::Type.newtype(:keycloak_ldap_user_provider) do
       [
         /^((\S+) on (\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :resource_name, lambda{|x| x} ],
-          [ :realm, lambda{|x| x} ],
+          [:name],
+          [:resource_name],
+          [:realm],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [:name],
         ],
       ],
     ]

--- a/lib/puppet/type/keycloak_protocol_mapper.rb
+++ b/lib/puppet/type/keycloak_protocol_mapper.rb
@@ -205,16 +205,16 @@ Puppet::Type.newtype(:keycloak_protocol_mapper) do
       [
         /^((.+) for (\S+) on (\S+))$/,
         [
-          [ :name, lambda{|x| x} ],
-          [ :resource_name, lambda{|x| x} ],
-          [ :client_template, lambda{|x| x} ],
-          [ :realm, lambda{|x| x} ],
+          [:name],
+          [:resource_name],
+          [:client_template],
+          [:realm],
         ],
       ],
       [
         /(.*)/,
         [
-          [ :name, lambda{|x| x} ],
+          [:name],
         ],
       ],
     ]


### PR DESCRIPTION
This commit makes the module compatible with `puppet generate types`.
Environment isolation is *really* important for a module where types
are having new parameters added on a regular basis.

See
https://tickets.puppetlabs.com/browse/MODULES-4505?focusedCommentId=418416&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418416
https://github.com/puppetlabs/puppetlabs-java_ks/pull/169
https://github.com/biemond/biemond-wildfly/pull/227