### PR TITLE
Fix for keycloak_protocol_mapper type property and type unit test improvements

### DIFF
--- a/lib/puppet/type/keycloak_protocol_mapper.rb
+++ b/lib/puppet/type/keycloak_protocol_mapper.rb
@@ -48,7 +48,15 @@ Puppet::Type.newtype(:keycloak_protocol_mapper) do
       'saml-user-property-mapper',
       'saml-role-list-mapper'
     )
-    defaultto 'oidc-usermodel-property-mapper'
+    defaultto do
+      if @resource[:protocol] == 'openid-connect'
+        'oidc-usermodel-property-mapper'
+      elsif @resource[:protocol] == 'saml'
+        'saml-user-property-mapper'
+      else
+        nil
+      end
+    end
     munge { |v| v }
   end
 
@@ -221,6 +229,12 @@ Puppet::Type.newtype(:keycloak_protocol_mapper) do
   end
 
   validate do
+    if self[:protocol] == 'openid-connect' && ! ['oidc-usermodel-property-mapper', 'oidc-full-name-mapper'].include?(self[:type])
+      self.fail "type #{self[:type]} is not valid for protocol openid-connect"
+    end
+    if self[:protocol] == 'saml' && ! ['saml-user-property-mapper', 'saml-role-list-mapper'].include?(self[:type])
+      self.fail "type #{self[:type]} is not valid for protocol saml"
+    end
     if self[:friendly_name] && self[:type] != 'saml-user-property-mapper'
       self.fail "friendly_name is not valid for type #{self[:type]}"
     end

--- a/spec/unit/puppet/type/keycloak_client_template_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_template_spec.rb
@@ -1,31 +1,40 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:keycloak_client_template) do
-  before(:each) do
-    @client = described_class.new(:name => 'foo', :realm => 'test')
+  let(:default_config) do
+    {
+      :name => 'foo',
+      :realm => 'test',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
   end
 
   it 'should add to catalog without raising an error' do
     catalog = Puppet::Resource::Catalog.new
     expect {
-      catalog.add_resource @client 
+      catalog.add_resource resource
     }.to_not raise_error
   end
 
   it 'should have a name' do
-    expect(@client[:name]).to eq('foo')
+    expect(resource[:name]).to eq('foo')
   end
 
   it 'should have resource_name default to name' do
-    expect(@client[:resource_name]).to eq('foo')
+    expect(resource[:resource_name]).to eq('foo')
   end
 
   it 'should have id default to name' do
-    expect(@client[:id]).to eq('foo')
+    expect(resource[:id]).to eq('foo')
   end
 
   it 'should have realm' do
-    expect(@client[:realm]).to eq('test')
+    expect(resource[:realm]).to eq('test')
   end
 
   it 'should handle componsite name' do
@@ -36,66 +45,81 @@ describe Puppet::Type.type(:keycloak_client_template) do
   end
 
   it 'should default to protocol=openid-connect' do
-    expect(@client[:protocol]).to eq('openid-connect')
+    expect(resource[:protocol]).to eq('openid-connect')
   end
 
   it 'should not allow invalid protocol' do
+    config[:protocol] = 'foo'
     expect {
-      @client[:protocol] = 'foo'
+      resource
     }.to raise_error
   end
+
+  defaults = {
+    :full_scope_allowed => :true
+  }
 
   # Test boolean properties
   [
     :full_scope_allowed,
   ].each do |p|
     it "should accept true for #{p.to_s}" do
-      @client[p] = true
-      expect(@client[p]).to eq(:true)
-      @client[p] = 'true'
-      expect(@client[p]).to eq(:true)
+      config[p] = true
+      expect(resource[p]).to eq(:true)
+    end
+    it "should accept true for #{p.to_s} string" do
+      config[p] = 'true'
+      expect(resource[p]).to eq(:true)
     end
     it "should accept false for #{p.to_s}" do
-      @client[p] = false
-      expect(@client[p]).to eq(:false)
-      @client[p] = 'false'
-      expect(@client[p]).to eq(:false)
+      config[p] = false
+      expect(resource[p]).to eq(:false)
+    end
+    it "should accept false for #{p.to_s} string" do
+      config[p] = 'false'
+      expect(resource[p]).to eq(:false)
     end
     it "should not accept strings for #{p.to_s}" do
+      config[p] = 'foo'
       expect {
-        @client[p] = 'foo'
+        resource
       }.to raise_error
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
   it 'should autorequire keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(:name => 'keycloak')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @client
+    catalog.add_resource resource
     catalog.add_resource keycloak_conn_validator
-    rel = @client.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_conn_validator.ref)
-    expect(rel.target.ref).to eq(@client.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire kcadm-wrapper.sh' do
     file = Puppet::Type.type(:file).new(:name => 'kcadm-wrapper.sh', :path => '/opt/keycloak/bin/kcadm-wrapper.sh')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @client
+    catalog.add_resource resource
     catalog.add_resource file
-    rel = @client.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(file.ref)
-    expect(rel.target.ref).to eq(@client.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire keycloak_realm' do
     keycloak_realm = Puppet::Type.type(:keycloak_realm).new(:name => 'test')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @client
+    catalog.add_resource resource
     catalog.add_resource keycloak_realm
-    rel = @client.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_realm.ref)
-    expect(rel.target.ref).to eq(@client.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
 end

--- a/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
@@ -1,31 +1,41 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:keycloak_ldap_mapper) do
-  before(:each) do
-    @component = described_class.new(:name => 'foo', :realm => 'test', :ldap => 'ldap-test')
+  let(:default_config) do
+    {
+      :name => 'foo',
+      :realm => 'test',
+      :ldap => 'ldap-test',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
   end
 
   it 'should add to catalog without raising an error' do
     catalog = Puppet::Resource::Catalog.new
     expect {
-      catalog.add_resource @component 
+      catalog.add_resource resource
     }.to_not raise_error
   end
 
   it 'should have a name' do
-    expect(@component[:name]).to eq('foo')
+    expect(resource[:name]).to eq('foo')
   end
 
   it 'should have resource_name default to name' do
-    expect(@component[:resource_name]).to eq('foo')
+    expect(resource[:resource_name]).to eq('foo')
   end
 
   it 'should have id default to name-realm' do
-    expect(@component[:id]).to eq('b84ed8ed-a7b1-502f-83f6-90132e68adef')
+    expect(resource[:id]).to eq('b84ed8ed-a7b1-502f-83f6-90132e68adef')
   end
 
   it 'should have realm' do
-    expect(@component[:realm]).to eq('test')
+    expect(resource[:realm]).to eq('test')
   end
 
   it 'should handle componsite name' do
@@ -45,19 +55,50 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
   end
 
   it 'should default to type=user-attribute-ldap-mapper' do
-    expect(@component[:type]).to eq('user-attribute-ldap-mapper')
+    expect(resource[:type]).to eq('user-attribute-ldap-mapper')
   end
 
   it 'should allow valid type' do
-    @component[:type] = 'full-name-ldap-mapper'
-    expect(@component[:type]).to eq('full-name-ldap-mapper')
+    config[:type] = 'full-name-ldap-mapper'
+    expect(resource[:type]).to eq('full-name-ldap-mapper')
   end
 
   it 'should not allow invalid type' do
+    config[:type] = 'foo'
     expect {
-      @component[:type] = 'foo'
+      resource
     }.to raise_error
   end
+
+  it 'should have is_mandatory_in_ldap be nil for full-name-ldap-mapper' do
+    config[:type] = 'full-name-ldap-mapper'
+    expect(resource[:is_mandatory_in_ldap]).to be_nil
+  end
+
+  it 'should have is_mandatory_in_ldap default to false for user-attribute-ldap-mapper' do
+    config[:type] = 'user-attribute-ldap-mapper'
+    expect(resource[:is_mandatory_in_ldap]).to be(:false)
+  end
+
+  it 'should have always_read_value_from_ldap be nil for full-name-ldap-mapper' do
+    config[:type] = 'full-name-ldap-mapper'
+    expect(resource[:always_read_value_from_ldap]).to be_nil
+  end
+
+  it 'should have always_read_value_from_ldap default to true for user-attribute-ldap-mapper' do
+    config[:type] = 'user-attribute-ldap-mapper'
+    expect(resource[:always_read_value_from_ldap]).to be(:true)
+  end
+
+  it 'should accept always_read_value_from_ldap=>false' do
+    config[:always_read_value_from_ldap] = false
+    expect(resource[:always_read_value_from_ldap]).to eq(:false)
+  end
+
+  defaults = {
+    :read_only => :true,
+    :write_only => :false
+  }
 
   # Test basic properties
   [
@@ -66,34 +107,14 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
     :user_model_attribute,
   ].each do |p|
     it "should accept a #{p.to_s}" do
-      @component[p] = 'foo'
-      expect(@component[p]).to eq('foo')
+      config[p] = 'foo'
+      expect(resource[p]).to eq('foo')
     end
-  end
-
-  it 'should have is_mandatory_in_ldap be nil for full-name-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'full-name-ldap-mapper')
-    expect(component[:is_mandatory_in_ldap]).to be_nil
-  end
-
-  it 'should have is_mandatory_in_ldap default to false for user-attribute-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'user-attribute-ldap-mapper')
-    expect(component[:is_mandatory_in_ldap]).to be(:false)
-  end
-
-  it 'should have always_read_value_from_ldap be nil for full-name-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'full-name-ldap-mapper')
-    expect(component[:always_read_value_from_ldap]).to be_nil
-  end
-
-  it 'should have always_read_value_from_ldap default to true for user-attribute-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'user-attribute-ldap-mapper')
-    expect(component[:always_read_value_from_ldap]).to be(:true)
-  end
-
-  it 'should accept always_read_value_from_ldap=>false' do
-    @component[:always_read_value_from_ldap] = false
-    expect(@component[:always_read_value_from_ldap]).to eq(:false)
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
   end
 
   # Test boolean properties
@@ -102,62 +123,72 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
     :write_only,
   ].each do |p|
     it "should accept true for #{p.to_s}" do
-      @component[p] = true
-      expect(@component[p]).to eq(:true)
-      @component[p] = 'true'
-      expect(@component[p]).to eq(:true)
+      config[p] = true
+      expect(resource[p]).to eq(:true)
+    end
+    it "should accept true for #{p.to_s} string" do
+      config[p] = 'true'
+      expect(resource[p]).to eq(:true)
     end
     it "should accept false for #{p.to_s}" do
-      @component[p] = false
-      expect(@component[p]).to eq(:false)
-      @component[p] = 'false'
-      expect(@component[p]).to eq(:false)
+      config[p] = false
+      expect(resource[p]).to eq(:false)
+    end
+    it "should accept false for #{p.to_s} string" do
+      config[p] = 'false'
+      expect(resource[p]).to eq(:false)
     end
     it "should not accept strings for #{p.to_s}" do
+      config[p] = 'foo'
       expect {
-        @component[p] = 'foo'
+        resource
       }.to raise_error
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
   it 'should autorequire keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(:name => 'keycloak')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @component
+    catalog.add_resource resource
     catalog.add_resource keycloak_conn_validator
-    rel = @component.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_conn_validator.ref)
-    expect(rel.target.ref).to eq(@component.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire kcadm-wrapper.sh' do
     file = Puppet::Type.type(:file).new(:name => 'kcadm-wrapper.sh', :path => '/opt/keycloak/bin/kcadm-wrapper.sh')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @component
+    catalog.add_resource resource
     catalog.add_resource file
-    rel = @component.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(file.ref)
-    expect(rel.target.ref).to eq(@component.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire keycloak_realm' do
     keycloak_realm = Puppet::Type.type(:keycloak_realm).new(:name => 'test')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @component
+    catalog.add_resource resource
     catalog.add_resource keycloak_realm
-    rel = @component.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_realm.ref)
-    expect(rel.target.ref).to eq(@component.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire keycloak_ldap_user_provider' do
     keycloak_ldap_user_provider = Puppet::Type.type(:keycloak_ldap_user_provider).new(:name => 'ldap', :realm => 'test')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @component
+    catalog.add_resource resource
     catalog.add_resource keycloak_ldap_user_provider
-    rel = @component.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_ldap_user_provider.ref)
-    expect(rel.target.ref).to eq(@component.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
 end

--- a/spec/unit/puppet/type/keycloak_ldap_user_provider_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_user_provider_spec.rb
@@ -17,7 +17,7 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
   it 'should add to catalog without raising an error' do
     catalog = Puppet::Resource::Catalog.new
     expect {
-      catalog.add_resource resource 
+      catalog.add_resource resource
     }.to_not raise_error
   end
 
@@ -114,6 +114,16 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
     }.to raise_error
   end
 
+  defaults = {
+    :priority => '0',
+    :batch_size_for_sync => '1000',
+    :username_ldap_attribute => 'uid',
+    :rdn_ldap_attribute => 'uid',
+    :uuid_ldap_attribute => 'entryUUID',
+    :import_enabled => :true,
+    :user_object_classes => ['inetOrgPerson','organizationalPerson'],
+  }
+
   # Test basic properties
   [
     :users_dn,
@@ -127,6 +137,11 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
     it "should accept a #{p.to_s}" do
       config[p] = 'foo'
       expect(resource[p]).to eq('foo')
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
@@ -152,6 +167,11 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
         resource
       }.to raise_error
     end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
   end
 
   # Array properties
@@ -161,6 +181,11 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
     it 'should accept array' do
       config[p] = ['foo','bar']
       expect(resource[p]).to eq(['foo','bar'])
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 

--- a/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
@@ -1,31 +1,41 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:keycloak_protocol_mapper) do
-  before(:each) do
-    @protocol_mapper = described_class.new(:name => 'foo', :realm => 'test', :client_template => 'oidc')
+  let(:default_config) do
+    {
+      :name => 'foo',
+      :realm => 'test',
+      :client_template => 'oidc',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
   end
 
   it 'should add to catalog without raising an error' do
     catalog = Puppet::Resource::Catalog.new
     expect {
-      catalog.add_resource @protocol_mapper 
+      catalog.add_resource resource
     }.to_not raise_error
   end
 
   it 'should have a name' do
-    expect(@protocol_mapper[:name]).to eq('foo')
+    expect(resource[:name]).to eq('foo')
   end
 
   it 'should have resource_name default to name' do
-    expect(@protocol_mapper[:resource_name]).to eq('foo')
+    expect(resource[:resource_name]).to eq('foo')
   end
 
   it 'should have id default to name-realm' do
-    expect(@protocol_mapper[:id]).to eq('b84ed8ed-a7b1-502f-83f6-90132e68adef')
+    expect(resource[:id]).to eq('b84ed8ed-a7b1-502f-83f6-90132e68adef')
   end
 
   it 'should have realm' do
-    expect(@protocol_mapper[:realm]).to eq('test')
+    expect(resource[:realm]).to eq('test')
   end
 
   it 'should handle componsite name' do
@@ -45,34 +55,203 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
   end
 
   it 'should default to protocol=openid-connect' do
-    expect(@protocol_mapper[:protocol]).to eq('openid-connect')
+    expect(resource[:protocol]).to eq('openid-connect')
   end
 
   it 'should not allow invalid protocol' do
+    config[:protocol] = 'foo'
     expect {
-      @protocol_mapper[:protocol] = 'foo'
+      resource
     }.to raise_error
   end
 
   it 'should default to type=oidc-usermodel-property-mapper' do
-    expect(@protocol_mapper[:type]).to eq('oidc-usermodel-property-mapper')
+    expect(resource[:type]).to eq('oidc-usermodel-property-mapper')
   end
 
   it 'should allow valid type' do
-    @protocol_mapper[:type] = 'oidc-full-name-mapper'
-    expect(@protocol_mapper[:type]).to eq('oidc-full-name-mapper')
+    config[:type] = 'oidc-full-name-mapper'
+    expect(resource[:type]).to eq('oidc-full-name-mapper')
   end
 
   it 'should allow valid type' do
-    @protocol_mapper[:type] = 'saml-user-property-mapper'
-    expect(@protocol_mapper[:type]).to eq('saml-user-property-mapper')
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    expect(resource[:type]).to eq('saml-user-property-mapper')
   end
 
   it 'should not allow invalid type' do
+    config[:type] = 'foo'
     expect {
-      @protocol_mapper[:type] = 'foo'
+      resource
     }.to raise_error
   end
+
+  it 'should have user_attribute be nil for full-name-ldap-mapper' do
+    config[:type] = 'oidc-full-name-mapper'
+    expect(resource[:user_attribute]).to be_nil
+  end
+
+  it 'should have user_attribute default to name for oidc-usermodel-property-mapper' do
+    config[:type] = 'oidc-usermodel-property-mapper'
+    expect(resource[:user_attribute]).to eq('foo')
+  end
+
+  it 'should have user_attribute default to name for saml-user-property-mapper' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    expect(resource[:user_attribute]).to eq('foo')
+  end
+
+  it 'should have json_type_label be nil for full-name-ldap-mapper' do
+    config[:type] = 'oidc-full-name-mapper'
+    expect(resource[:json_type_label]).to be_nil
+  end
+
+  it 'should have json_type_label default to String for oidc-usermodel-property-mapper' do
+    config[:type] = 'oidc-usermodel-property-mapper'
+    expect(resource[:json_type_label]).to eq('String')
+  end
+
+  it 'should have friendly_name as nil' do
+    expect(resource[:friendly_name]).to be_nil
+  end
+
+  it 'should default friend_name for saml' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    expect(resource[:friendly_name]).to eq('foo')
+  end
+
+  it 'should allow valid friendly_name' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    config[:friendly_name] = 'email'
+    expect(resource[:friendly_name]).to eq('email')
+  end
+
+  it 'should have attribute_name as nil' do
+    expect(resource[:attribute_name]).to be_nil
+  end
+
+  it 'should default attribute_name for saml' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    expect(resource[:attribute_name]).to eq('foo')
+  end
+
+  it 'should allow valid attribute_name' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-user-property-mapper'
+    config[:attribute_name] = 'email'
+    expect(resource[:attribute_name]).to eq('email')
+  end
+
+  it 'should default for id_token_claim' do
+    expect(resource[:id_token_claim]).to eq(:true)
+  end
+
+  it 'should not default id_token_claim for saml' do
+    config[:protocol] = 'saml'
+    expect(resource[:id_token_claim]).to be_nil
+  end
+
+  it 'should accept true for id_token_claim' do
+    config[:id_token_claim] = true
+    expect(resource[:id_token_claim]).to eq(:true)
+  end
+
+  it 'should accept true for id_token_claim as string' do
+    config[:id_token_claim] = 'true'
+    expect(resource[:id_token_claim]).to eq(:true)
+  end
+
+  it 'should accept false for id_token_claim' do
+    config[:id_token_claim] = false
+    expect(resource[:id_token_claim]).to eq(:false)
+  end
+
+  it 'should accept false for id_token_claim as string' do
+    config[:id_token_claim] = 'false'
+    expect(resource[:id_token_claim]).to eq(:false)
+  end
+
+  it "should not accept strings for id_token_claim" do
+    config[:id_token_claim] = 'foo'
+    expect {
+      resource
+    }.to raise_error
+  end
+
+  it 'should default for access_token_claim' do
+    expect(resource[:access_token_claim]).to eq(:true)
+  end
+
+  it 'should not default access_token_claim for saml' do
+    config[:protocol] = 'saml'
+    expect(resource[:access_token_claim]).to be_nil
+  end
+
+  it 'should accept true for access_token_claim' do
+    config[:access_token_claim] = true
+    expect(resource[:access_token_claim]).to eq(:true)
+    config[:access_token_claim] = 'true'
+    expect(resource[:access_token_claim]).to eq(:true)
+  end
+
+  it 'should accept false for access_token_claim' do
+    config[:access_token_claim] = false
+    expect(resource[:access_token_claim]).to eq(:false)
+    config[:access_token_claim] = 'false'
+    expect(resource[:access_token_claim]).to eq(:false)
+  end
+
+  it "should not accept strings for access_token_claim" do
+    config[:access_token_claim] = 'foo'
+    expect {
+      resource
+    }.to raise_error
+  end
+
+  it 'should default for userinfo_token_claim' do
+    expect(resource[:userinfo_token_claim]).to eq(:true)
+  end
+
+  it 'should not default userinfo_token_claim for saml' do
+    config[:protocol] = 'saml'
+    expect(resource[:userinfo_token_claim]).to be_nil
+  end
+
+  it 'should accept true for userinfo_token_claim' do
+    config[:userinfo_token_claim] = true
+    expect(resource[:userinfo_token_claim]).to eq(:true)
+  end
+
+  it 'should accept true for userinfo_token_claim as string' do
+    config[:userinfo_token_claim] = 'true'
+    expect(resource[:userinfo_token_claim]).to eq(:true)
+  end
+
+  it 'should accept false for userinfo_token_claim' do
+    config[:userinfo_token_claim] = false
+    expect(resource[:userinfo_token_claim]).to eq(:false)
+  end
+
+  it 'should accept false for userinfo_token_claim as string' do
+    config[:userinfo_token_claim] = 'false'
+    expect(resource[:userinfo_token_claim]).to eq(:false)
+  end
+
+  it "should not accept strings for userinfo_token_claim" do
+    config[:userinfo_token_claim] = 'foo'
+    expect {
+      resource
+    }.to raise_error
+  end
+
+  defaults = {
+    :consent_required => :true,
+  }
 
   # Test basic properties
   [
@@ -80,141 +259,140 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
     :claim_name,
   ].each do |p|
     it "should accept a #{p.to_s}" do
-      @protocol_mapper[p] = 'foo'
-      expect(@protocol_mapper[p]).to eq('foo')
+      config[p] = 'foo'
+      expect(resource[p]).to eq('foo')
     end
-  end
-
-  it 'should have user_attribute be nil for full-name-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'oidc-full-name-mapper')
-    expect(component[:user_attribute]).to be_nil
-  end
-
-  it 'should have user_attribute default to name for oidc-usermodel-property-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'oidc-usermodel-property-mapper')
-    expect(component[:user_attribute]).to eq('foo')
-  end
-
-  it 'should have json_type_label be nil for full-name-ldap-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'oidc-full-name-mapper')
-    expect(component[:json_type_label]).to be_nil
-  end
-
-  it 'should have json_type_label default to String for oidc-usermodel-property-mapper' do
-    component = described_class.new(:name => 'foo', :realm => 'test', :type => 'oidc-usermodel-property-mapper')
-    expect(component[:json_type_label]).to eq('String')
-  end
-
-  it 'should have friendly_name as nil' do
-    expect(@protocol_mapper[:friendly_name]).to be_nil
-  end
-
-  it 'should allow valid friendly_name' do
-    @protocol_mapper[:type] = 'saml-user-property-mapper'
-    @protocol_mapper[:friendly_name] = 'email'
-    expect(@protocol_mapper[:friendly_name]).to eq('email')
-  end
-
-  it 'should have attribute_name as nil' do
-    expect(@protocol_mapper[:attribute_name]).to be_nil
-  end
-
-  it 'should allow valid attribute_name' do
-    @protocol_mapper[:type] = 'saml-user-property-mapper'
-    @protocol_mapper[:attribute_name] = 'email'
-    expect(@protocol_mapper[:attribute_name]).to eq('email')
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
   end
 
   # Test boolean properties
   [
     :consent_required,
-    :id_token_claim,
-    :access_token_claim,
-    :userinfo_token_claim,
   ].each do |p|
     it "should accept true for #{p.to_s}" do
-      @protocol_mapper[p] = true
-      expect(@protocol_mapper[p]).to eq(:true)
-      @protocol_mapper[p] = 'true'
-      expect(@protocol_mapper[p]).to eq(:true)
+      config[p] = true
+      expect(resource[p]).to eq(:true)
+    end
+    it "should accept true for #{p.to_s} as string" do
+      config[p] = 'true'
+      expect(resource[p]).to eq(:true)
     end
     it "should accept false for #{p.to_s}" do
-      @protocol_mapper[p] = false
-      expect(@protocol_mapper[p]).to eq(:false)
-      @protocol_mapper[p] = 'false'
-      expect(@protocol_mapper[p]).to eq(:false)
+      config[p] = false
+      expect(resource[p]).to eq(:false)
+    end
+    it "should accept false for #{p.to_s} as string" do
+      config[p] = 'false'
+      expect(resource[p]).to eq(:false)
     end
     it "should not accept strings for #{p.to_s}" do
+      config[p] = 'foo'
       expect {
-        @protocol_mapper[p] = 'foo'
+        resource
       }.to raise_error
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
   it 'should accept value for attribute_nameformat' do
-    @protocol_mapper[:attribute_nameformat] = 'Basic'
-    expect(@protocol_mapper[:attribute_nameformat]).to eq(:basic)
-    @protocol_mapper[:attribute_nameformat] = 'uri'
-    expect(@protocol_mapper[:attribute_nameformat]).to eq(:uri)
+    config[:protocol] = 'saml'
+    config[:attribute_nameformat] = 'Basic'
+    expect(resource[:attribute_nameformat]).to eq(:basic)
+  end
+
+  it 'should accept value for attribute_nameformat' do
+    config[:protocol] = 'saml'
+    config[:attribute_nameformat] = 'uri'
+    expect(resource[:attribute_nameformat]).to eq(:uri)
   end
 
   it 'should not accept invalid value for attribute_nameformat' do
+    config[:protocol] = 'saml'
+    config[:attribute_nameformat] = 'foo'
     expect {
-      @protocol_mapper[:attribute_nameformat] = 'foo'
+      resource
     }.to raise_error
   end
 
   it 'should accept value for single' do
-    @protocol_mapper[:single] = false
-    expect(@protocol_mapper[:single]).to eq(:false)
-    @protocol_mapper[:single] = 'false'
-    expect(@protocol_mapper[:single]).to eq(:false)
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-role-list-mapper'
+    config[:single] = false
+    expect(resource[:single]).to eq(:false)
+  end
+
+  it 'should accept value for single string' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-role-list-mapper'
+    config[:single] = 'false'
+    expect(resource[:single]).to eq(:false)
+  end
+
+  it 'should have default for single' do
+    expect(resource[:single]).to be_nil
+  end
+
+  it 'should have default for single and saml-role-list-mapper' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-role-list-mapper'
+    expect(resource[:single]).to eq(:false)
   end
 
   it 'should not accept invalid value for single' do
+    config[:protocol] = 'saml'
+    config[:type] = 'saml-role-list-mapper'
+    config[:single] = 'foo'
     expect {
-      @protocol_mapper[:single] = 'foo'
+      resource
     }.to raise_error
   end
 
   it 'should autorequire keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(:name => 'keycloak')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @protocol_mapper
+    catalog.add_resource resource
     catalog.add_resource keycloak_conn_validator
-    rel = @protocol_mapper.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_conn_validator.ref)
-    expect(rel.target.ref).to eq(@protocol_mapper.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire kcadm-wrapper.sh' do
     file = Puppet::Type.type(:file).new(:name => 'kcadm-wrapper.sh', :path => '/opt/keycloak/bin/kcadm-wrapper.sh')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @protocol_mapper
+    catalog.add_resource resource
     catalog.add_resource file
-    rel = @protocol_mapper.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(file.ref)
-    expect(rel.target.ref).to eq(@protocol_mapper.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire keycloak_realm' do
     keycloak_realm = Puppet::Type.type(:keycloak_realm).new(:name => 'test')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @protocol_mapper
+    catalog.add_resource resource
     catalog.add_resource keycloak_realm
-    rel = @protocol_mapper.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_realm.ref)
-    expect(rel.target.ref).to eq(@protocol_mapper.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire keycloak_client_template' do
     keycloak_client_template = Puppet::Type.type(:keycloak_client_template).new(:name => 'oidc', :realm => 'test')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @protocol_mapper
+    catalog.add_resource resource
     catalog.add_resource keycloak_client_template
-    rel = @protocol_mapper.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_client_template.ref)
-    expect(rel.target.ref).to eq(@protocol_mapper.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
 end

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -1,24 +1,42 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:keycloak_realm) do
-  before(:each) do
-    @realm = described_class.new(:name => 'test')
+  let(:default_config) do
+    {
+      :name => 'test',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
   end
 
   it 'should add to catalog without raising an error' do
     catalog = Puppet::Resource::Catalog.new
     expect {
-      catalog.add_resource @realm 
+      catalog.add_resource resource
     }.to_not raise_error
   end
 
   it 'should have a name' do
-    expect(@realm[:name]).to eq('test')
+    expect(resource[:name]).to eq('test')
   end
 
   it 'should have id default to name' do
-    expect(@realm[:id]).to eq('test')
+    expect(resource[:id]).to eq('test')
   end
+
+  defaults = {
+    :login_theme => 'keycloak',
+    :account_theme => 'keycloak',
+    :admin_theme => 'keycloak',
+    :email_theme => 'keycloak',
+    :enabled => :true,
+    :remember_me => :false,
+    :login_with_email_allowed => :true,
+  }
 
   # Test basic properties
   [
@@ -30,8 +48,13 @@ describe Puppet::Type.type(:keycloak_realm) do
     :email_theme,
   ].each do |p|
     it "should accept a #{p.to_s}" do
-      @realm[p] = 'foo'
-      expect(@realm[p]).to eq('foo')
+      config[p] = 'foo'
+      expect(resource[p]).to eq('foo')
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
@@ -41,42 +64,52 @@ describe Puppet::Type.type(:keycloak_realm) do
     :login_with_email_allowed,
   ].each do |p|
     it "should accept true for #{p.to_s}" do
-      @realm[p] = true
-      expect(@realm[p]).to eq(:true)
-      @realm[p] = 'true'
-      expect(@realm[p]).to eq(:true)
+      config[p] = true
+      expect(resource[p]).to eq(:true)
+    end
+    it "should accept true for #{p.to_s} string" do
+      config[p] = 'true'
+      expect(resource[p]).to eq(:true)
     end
     it "should accept false for #{p.to_s}" do
-      @realm[p] = false
-      expect(@realm[p]).to eq(:false)
-      @realm[p] = 'false'
-      expect(@realm[p]).to eq(:false)
+      config[p] = false
+      expect(resource[p]).to eq(:false)
+    end
+    it "should accept false for #{p.to_s} string" do
+      config[p] = 'false'
+      expect(resource[p]).to eq(:false)
     end
     it "should not accept strings for #{p.to_s}" do
+      config[p] = 'foo'
       expect {
-        @realm[p] = 'foo'
+        resource
       }.to raise_error
+    end
+    if defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
     end
   end
 
   it 'should autorequire keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(:name => 'keycloak')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @realm
+    catalog.add_resource resource
     catalog.add_resource keycloak_conn_validator
-    rel = @realm.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(keycloak_conn_validator.ref)
-    expect(rel.target.ref).to eq(@realm.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
   it 'should autorequire kcadm-wrapper.sh' do
     file = Puppet::Type.type(:file).new(:name => 'kcadm-wrapper.sh', :path => '/opt/keycloak/bin/kcadm-wrapper.sh')
     catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource @realm
+    catalog.add_resource resource
     catalog.add_resource file
-    rel = @realm.autorequire[0]
+    rel = resource.autorequire[0]
     expect(rel.source.ref).to eq(file.ref)
-    expect(rel.target.ref).to eq(@realm.ref)
+    expect(rel.target.ref).to eq(resource.ref)
   end
 
 end


### PR DESCRIPTION
keycloak_protocol_mapper type property will default to `saml-user-property-mapper` when `protocol` is `saml`.
Add some extra validations to keycloak_protocol_mapper around `type` and `protocol` combinations