### PR TITLE
Https support for Keycloak installation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,17 @@ class keycloak::config {
     mode   => '0750',
   }
 
+  if $keycloak::https {
+    #Copy keycloak keystore
+    file {'Keycloak keystore':
+      path   => "${keycloak::install_base}/standalone/configuration/${keycloak::ssl_keystore_file}",
+      owner  => $keycloak::user,
+      group  => $keycloak::group,
+      mode   => '0600',
+      source => "${keycloak::ssl_keystore_source}/${keycloak::ssl_keystore_file}"
+    }
+  }
+
   file { "${keycloak::install_base}/config.cli":
     ensure    => 'file',
     owner     => $keycloak::user,

--- a/manifests/datasource/oracle.pp
+++ b/manifests/datasource/oracle.pp
@@ -1,0 +1,39 @@
+# Private class.
+class keycloak::datasource::oracle (
+  $jar_file      = $keycloak::oracle_jar_file,
+  $jar_source    = $keycloak::oracle_jar_source,
+  $module_source = 'puppet:///modules/keycloak/database/oracle/module.xml',
+) {
+  assert_private()
+
+  $module_dir = "${keycloak::install_dir}/keycloak-${keycloak::version}/modules/system/layers/keycloak/org/oracle/main"
+
+  exec { "mkdir -p ${module_dir}":
+    path    => '/usr/bin:/bin',
+    creates => $module_dir,
+    user    => $keycloak::user,
+    group   => $keycloak::group,
+  }
+  -> file { $module_dir:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0755',
+  }
+
+  file { "${module_dir}/${jar_file}":
+    ensure => 'file',
+    source => $jar_source,
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0644',
+  }
+
+  file { "${$module_dir}/module.xml":
+    ensure => 'file',
+    source => $module_source,
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0644',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,21 @@
 # @param client_templates
 #   Hash that is used to define keycloak::client_template resources.
 #   Default is `{}`.
+# @param https 
+#   Defines if https should be configured.
+#   Default is false.
+# @param ssl_keystore_file 
+#   Name of the keystore file. Will be placed in configuration folder in Keycloak installation
+#   Default is not set.
+# @param ssl_keystore_source 
+#   Path to the keystore to be copied from.
+#   Default is not set
+# @param ssl_keystore_pass 
+#   Password to SSL keystore.
+#   Default is not set.
+# @param https_port 
+#   Port for HTTPS connection.
+#   Default is 8443
 #
 class keycloak (
   String $version               = '3.4.1.Final',
@@ -140,6 +155,12 @@ class keycloak (
   Boolean $theme_cache_templates = true,
   Hash $realms = {},
   Hash $client_templates = {},
+  Boolean $https = false,
+  Integer $https_port = 8443,
+  Optional[String] $ssl_keystore_file = undef,
+  Optional[String] $ssl_keystore_source = undef,
+  Optional[String] $ssl_keystore_pass = undef,
+
 ) inherits keycloak::params {
 
   $download_url = pick($package_url, "https://downloads.jboss.org/keycloak/${version}/keycloak-${version}.tar.gz")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,12 @@
 # @param client_templates
 #   Hash that is used to define keycloak::client_template resources.
 #   Default is `{}`.
+# @param oracle_jar_file
+#   Oracle JDBC driver to use. Only use if $datasource_driver is set to oracle
+#   Default is not defined
+# @param oracle_jar_source
+#   Source for Oracle JDBC driver - could be puppet link or local file on the node. Only use if $datasource_driver is set to oracle
+#   Default is not set
 # @param https 
 #   Defines if https should be configured.
 #   Default is false.
@@ -155,6 +161,8 @@ class keycloak (
   Boolean $theme_cache_templates = true,
   Hash $realms = {},
   Hash $client_templates = {},
+  Optional[String] $oracle_jar_file = undef,
+  Optional[String] $oracle_jar_source = undef,
   Boolean $https = false,
   Integer $https_port = 8443,
   Optional[String] $ssl_keystore_file = undef,
@@ -174,6 +182,10 @@ class keycloak (
       $datasource_connection_url = "jdbc:mysql://${db_host}:${db_port}/${datasource_dbname}"
     }
     default: {}
+  }
+
+  if ($datasource_driver == 'oracle') and (($oracle_jar_file == undef) or ($oracle_jar_source == undef)) {
+    fail('Using Oracle RDBMS requires definition of jar_file and jar_source for Oracle JDBC driver. Refer to module documentation')
   }
 
   $install_base = "${keycloak::install_dir}/keycloak-${keycloak::version}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,16 +192,18 @@ class keycloak (
 
   Class["keycloak::datasource::${datasource_driver}"]~>Class['keycloak::service']
 
-  keycloak_conn_validator { 'keycloak':
-    keycloak_server => 'localhost',
-    keycloak_port   => $http_port,
-    use_ssl         => false,
-    timeout         => 60,
-    test_url        => '/auth/realms/master/.well-known/openid-configuration',
-    require         => Class['keycloak::service'],
+# Keycloak conn validator is active only for HTTP connection, as HTTPS connection works only with Puppet certs and not custom keystore (Ticket SERVER-1543)
+  if ! $keycloak::https {
+    keycloak_conn_validator { 'keycloak':
+      keycloak_server => $keycloak_ip,
+      keycloak_port   => $http_port,
+      use_ssl         => false,
+      timeout         => 60,
+      test_url        => '/auth/realms/master/.well-known/openid-configuration',
+      require         => Class['keycloak::service'],
+    }
   }
 
   create_resources('keycloak_realm', $realms)
   create_resources('keycloak::client_template', $client_templates)
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,7 +195,7 @@ class keycloak (
 # Keycloak conn validator is active only for HTTP connection, as HTTPS connection works only with Puppet certs and not custom keystore (Ticket SERVER-1543)
   if ! $keycloak::https {
     keycloak_conn_validator { 'keycloak':
-      keycloak_server => $keycloak_ip,
+      keycloak_server => localhost,
       keycloak_port   => $http_port,
       use_ssl         => false,
       timeout         => 60,

--- a/templates/config.cli.erb
+++ b/templates/config.cli.erb
@@ -46,3 +46,12 @@ end-if
 /subsystem=keycloak-server/theme=defaults/:write-attribute(name=staticMaxAge, value=<%= scope['keycloak::theme_static_max_age'] %>)
 /subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheThemes, value=<%= scope['keycloak::theme_cache_themes'] %>)
 /subsystem=keycloak-server/theme=defaults/:write-attribute(name=cacheTemplates, value=<%= scope['keycloak::theme_cache_templates'] %>)
+<%- if scope['keycloak::https'] -%>
+if (outcome != success) of /core-service=management/security-realm=HTTPSRealm:read-resource
+batch
+/core-service=management/security-realm=HTTPSRealm/:add
+/core-service=management/security-realm=HTTPSRealm/server-identity=ssl:add(keystore-path=<%= scope['keycloak::ssl_keystore_file'] %>, keystore-relative-to="jboss.server.config.dir", keystore-password=<%= scope['keycloak::ssl_keystore_pass'] %>)
+/subsystem=undertow/server=default-server/https-listener=https:add(socket-binding=https, security-realm=HTTPSRealm)
+run-batch
+end-if
+<%- end -%>

--- a/templates/config.cli.erb
+++ b/templates/config.cli.erb
@@ -29,6 +29,15 @@ end-if
 /subsystem=datasources/data-source=KeycloakDS:undefine-attribute(name=background-validation-millis)
 /subsystem=datasources/data-source=KeycloakDS:undefine-attribute(name=flush-strategy)
 <%- end -%>
+<%- elsif scope['keycloak::datasource_driver'] == 'oracle' -%>
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=background-validation, value=true)
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=check-valid-connection-sql, value="SELECT 1 FROM DUAL")
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=background-validation-millis, value=60000)
+/subsystem=datasources/data-source=KeycloakDS:write-attribute(name=flush-strategy, value=IdleConnections)
+if (outcome != success) of /subsystem=datasources/jdbc-driver=oracle:read-resource
+/subsystem=datasources/jdbc-driver=oracle:add(driver-module-name=org.oracle,driver-name=oracle,driver-xa-datasource-class-name=oracle.jdbc.xa.client.OracleXADataSource)
+end-if
+<%- end -%>
 <%- if scope['keycloak::truststore'] -%>
 if (outcome != success) of /subsystem=keycloak-server/spi=truststore:read-resource
 /subsystem=keycloak-server/spi=truststore/:add

--- a/templates/config.cli.erb
+++ b/templates/config.cli.erb
@@ -54,4 +54,31 @@ batch
 /subsystem=undertow/server=default-server/https-listener=https:add(socket-binding=https, security-realm=HTTPSRealm)
 run-batch
 end-if
+if (outcome == success) of /subsystem=remoting/http-connector=http-remoting-connector/:read-resource
+/subsystem=remoting/http-connector=http-remoting-connector/:write-attribute(name=connector-ref, value=https)
+end-if
+if (outcome == success) of /subsystem=undertow/server=default-server/http-listener=default/:read-resource
+/subsystem=undertow/server=default-server/http-listener=default:remove
+end-if
+/core-service=management/security-realm="ManagementRealm"/server-identity=ssl:add(keystore-path=<%= scope['keycloak::ssl_keystore_file'] %>, keystore-relative-to="jboss.server.config.dir", keystore-password=<%= scope['keycloak::ssl_keystore_pass'] %>)
+/core-service=management/management-interface=http-interface/:write-attribute(name=secure-socket-binding, value=management-https)
+/core-service=management/management-interface=http-interface/:undefine-attribute(name=socket-binding)
+<%- else -%>
+if (outcome == success) of /core-service=management/security-realm=HTTPSRealm:read-resource
+/core-service=management/security-realm=HTTPSRealm:remove
+end-if
+if (outcome == success) of /subsystem=undertow/server=default-server/https-listener=https/:read-resource
+/subsystem=undertow/server=default-server/https-listener=https/:remove
+end-if
+if (outcome != success) of /subsystem=undertow/server=default-server/http-listener=default/:read-resource
+/subsystem=undertow/server=default-server/http-listener=default:add(socket-binding=http)
+end-if
+if (outcome == success) of /core-service=management/security-realm="ManagementRealm"/server-identity=ssl/:read-resource
+/core-service=management/security-realm="ManagementRealm"/server-identity=ssl/:remove
+end-if
+if (outcome == success) of /subsystem=remoting/http-connector=http-remoting-connector/:read-resource
+/subsystem=remoting/http-connector=http-remoting-connector/:write-attribute(name=connector-ref, value=default)
+end-if
+/core-service=management/management-interface=http-interface/:undefine-attribute(name=secure-socket-binding)
+/core-service=management/management-interface=http-interface/:write-attribute(name=socket-binding, value=management-http)
 <%- end -%>

--- a/templates/kcadm-wrapper.sh.erb
+++ b/templates/kcadm-wrapper.sh.erb
@@ -2,4 +2,14 @@
 
 KCADM="<%= scope['keycloak::install_base'] %>/bin/kcadm.sh"
 
+<%- if scope['keycloak::https'] -%>
+KEYCLOAK_TRUSTSTORE_PATH="<%= scope['keycloak::install_base'] %>/standalone/configuration/<%= scope['keycloak::ssl_keystore_file'] %>"
+KEYCLOAK_TRUSTSTORE_PASS="<%= scope['keycloak::ssl_keystore_pass'] %>"
+#Adding trustore information to Keycloak session
+${KCADM} config truststore --trustpass ${KEYCLOAK_TRUSTSTORE_PASS} ${KEYCLOAK_TRUSTSTORE_PATH}
+
+${KCADM} "$@" --server https://<%= @facts['networking']['fqdn'] %>:<%= scope['keycloak::https_port'] %>/auth --realm master --user <%= scope['keycloak::admin_user'] %> --password <%= scope['keycloak::admin_user_password'] %>
+<%- else -%>
 ${KCADM} "$@" --no-config --server http://localhost:<%= scope['keycloak::http_port'] %>/auth --realm master --user <%= scope['keycloak::admin_user'] %> --password <%= scope['keycloak::admin_user_password'] %>
+<%- end -%>
+

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -5,9 +5,16 @@ After=network.target
 [Service]
 Type=idle
 #Environment="JAVA_OPTS=-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
+
+<%- if scope['keycloak::https'] -%>
+Environment="KEYCLOACK_BIND_PORT=-Djboss.https.port=<%= scope['keycloak::https_port'] %>"
+<%- else %>
+Environment="KEYCLOACK_BIND_PORT=-Djboss.http.port=<%= scope['keycloak::http_port'] %>"
+<%- end -%>
+
 User=<%= scope['keycloak::user'] %>
 Group=<%= scope['keycloak::group'] %>
-ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>
+ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 ${KEYCLOACK_BIND_PORT}
 TimeoutStartSec=600
 TimeoutStopSec=600
 


### PR DESCRIPTION
Enables HTTPS support for Keycloak installations when HTTPS_Proxy is not used. 

Lacks Keycloak_conn_validator due to issues with SSL truststore in puppet_http_connector (see Puppet ticket SERVER-1543)
