### PR TITLE
Fix keycloak_ldap_mapper id handling and write_only property

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 group :system_tests do
   gem 'beaker', '~>4.x',              :require => false
   gem 'beaker-docker',                :require => false
-  gem 'beaker-puppet',                :require => false
+  gem 'beaker-puppet', '< 1.15.0',    :require => false
   gem 'beaker-rspec',                 :require => false
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false

--- a/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
     fail("Ldap is mandatory for #{resource.type} #{resource.name}") if resource[:ldap].nil?
 
     data = {}
-    data[:id] = resource[:id]
+    data[:id] = resource[:id] || name_uuid(resource[:name])
     data[:name] = resource[:resource_name]
     data[:parentId] = resource[:ldap]
     data[:providerId] = resource[:type]
@@ -112,7 +112,7 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
   def destroy
     fail("Realm is mandatory for #{resource.type} #{resource.name}") if resource[:realm].nil?
     begin
-      kcadm('delete', "components/#{resource[:id]}", resource[:realm])
+      kcadm('delete', "components/#{id}", resource[:realm])
     rescue Exception => e
       raise Puppet::Error, "kcadm delete realm failed\nError message: #{e.message}"
     end
@@ -172,7 +172,7 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
       t.close
       Puppet.debug(IO.read(t.path))
       begin
-        kcadm('update', "components/#{resource[:id]}", resource[:realm], t.path)
+        kcadm('update', "components/#{id}", resource[:realm], t.path)
       rescue Exception => e
         raise Puppet::Error, "kcadm update component failed\nError message: #{e.message}"
       end

--- a/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
@@ -64,9 +64,6 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
   end
 
   def create
-    fail("Realm is mandatory for #{resource.type} #{resource.name}") if resource[:realm].nil?
-    fail("Ldap is mandatory for #{resource.type} #{resource.name}") if resource[:ldap].nil?
-
     data = {}
     data[:id] = resource[:id] || name_uuid(resource[:name])
     data[:name] = resource[:resource_name]
@@ -110,7 +107,6 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
   end
 
   def destroy
-    fail("Realm is mandatory for #{resource.type} #{resource.name}") if resource[:realm].nil?
     begin
       kcadm('delete', "components/#{id}", resource[:realm])
     rescue Exception => e
@@ -137,9 +133,6 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
 
   def flush
     if not @property_flush.empty?
-      fail("Realm is mandatory for #{resource.type} #{resource.name}") if resource[:realm].nil?
-      fail("Ldap is mandatory for #{resource.type} #{resource.name}") if resource[:ldap].nil?
-
       data = {}
       data[:providerId] = resource[:type]
       data[:providerType] = 'org.keycloak.storage.ldap.mappers.LDAPStorageMapper'

--- a/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb
@@ -87,6 +87,12 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
             next
           end
         end
+        # write.only only belongs to full-name-ldap-mapper
+        if resource[:type] != 'full-name-ldap-mapper'
+          if property == :write_only
+            next
+          end
+        end
         data[:config][key] = [resource[property.to_sym]]
       end
     end
@@ -148,6 +154,12 @@ Puppet::Type.type(:keycloak_ldap_mapper).provide(:kcadm, :parent => Puppet::Prov
           # is.mandatory.in.ldap and user.model.attribute only belong to user-attribute-ldap-mapper
           if resource[:type] != 'user-attribute-ldap-mapper'
             if property == :is_mandatory_in_ldap || property == :user_model_attribute || property == :always_read_value_from_ldap
+              next
+            end
+          end
+          # write.only only belongs to full-name-ldap-mapper
+          if resource[:type] != 'full-name-ldap-mapper'
+            if property == :write_only
               next
             end
           end

--- a/lib/puppet/type/keycloak_ldap_mapper.rb
+++ b/lib/puppet/type/keycloak_ldap_mapper.rb
@@ -128,4 +128,16 @@ Manage Keycloak LDAP attribute mappers
       ],
     ]
   end
+
+  validate do
+    required_properties = [
+      :realm,
+      :ldap,
+    ]
+    required_properties.each do |property|
+      if self[property].nil?
+        fail "You must provide a value for #{property}"
+      end
+    end
+  end
 end

--- a/lib/puppet/type/keycloak_ldap_mapper.rb
+++ b/lib/puppet/type/keycloak_ldap_mapper.rb
@@ -23,10 +23,7 @@ Manage Keycloak LDAP attribute mappers
   end
 
   newparam(:id) do
-    desc 'Id. Defaults to UUID generated from `name`.'
-    defaultto do
-      Puppet::Provider::Keycloak_API.name_uuid(@resource[:name])
-    end
+    desc 'Id.'
   end
 
   newparam(:resource_name) do

--- a/lib/puppet/type/keycloak_ldap_mapper.rb
+++ b/lib/puppet/type/keycloak_ldap_mapper.rb
@@ -52,11 +52,11 @@ Manage Keycloak LDAP attribute mappers
   end
 
   newproperty(:ldap_attribute) do
-    desc 'ldapAttribute'
+    desc 'ldap.attribute'
   end
 
   newproperty(:user_model_attribute) do
-    desc 'userModelAttribute'
+    desc 'user.model.attribute'
   end
 
   newproperty(:is_mandatory_in_ldap) do
@@ -83,15 +83,21 @@ Manage Keycloak LDAP attribute mappers
   end
 
   newproperty(:read_only, :boolean => true) do
-    desc "readOnly"
+    desc "read.nly"
     newvalues(:true, :false)
     defaultto :true
   end
 
   newproperty(:write_only, :boolean => true) do
-    desc "writeOnly"
+    desc "write.only.  Defaults to `false` if `type` is `full-name-ldap-mapper`."
     newvalues(:true, :false)
-    defaultto :false
+    defaultto do
+      if @resource[:type] == 'full-name-ldap-mapper'
+        :false
+      else
+        nil
+      end
+    end
   end
 
   autorequire(:keycloak_ldap_user_provider) do

--- a/spec/acceptance/3_ldap_spec.rb
+++ b/spec/acceptance/3_ldap_spec.rb
@@ -21,6 +21,12 @@ describe 'keycloak_ldap_user_provider:' do
         type => 'full-name-ldap-mapper',
         ldap_attribute => 'foo',
       }
+      keycloak_ldap_mapper { "first name for LDAP-test on test":
+        ensure               => 'present',
+        type                 => 'user-attribute-ldap-mapper',
+        user_model_attribute => 'firstName',
+        ldap_attribute       => 'givenName',
+      }
       EOS
 
       apply_manifest(pp, :catch_failures => true)
@@ -42,6 +48,16 @@ describe 'keycloak_ldap_user_provider:' do
         d = data.select { |o| o['name'] == 'full-name' }[0]
         expect(d['providerId']).to eq('full-name-ldap-mapper')
         expect(d['config']['ldap.full.name.attribute']).to eq(['foo'])
+      end
+    end
+
+    it 'should have set firstName LDAP mapper' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get components -r test' do
+        data = JSON.parse(stdout)
+        d = data.select { |o| o['name'] == 'first name' }[0]
+        expect(d['providerId']).to eq('user-attribute-ldap-mapper')
+        expect(d['config']['user.model.attribute']).to eq(['firstName'])
+        expect(d['config']['ldap.attribute']).to eq(['givenName'])
       end
     end
   end

--- a/spec/acceptance/3_ldap_spec.rb
+++ b/spec/acceptance/3_ldap_spec.rb
@@ -185,4 +185,31 @@ describe 'keycloak_ldap_user_provider:' do
       end
     end
   end
+
+  context 'ensure => absent' do
+    it 'should run successfully' do
+      pp =<<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_ldap_mapper { 'full-name':
+        ensure => 'absent',
+        realm  => 'test',
+        ldap   => 'LDAP-test',
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'should have deleted ldap mapper' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get components -r test' do
+        data = JSON.parse(stdout)
+        d = data.select { |o| o['name'] == 'full-name' }[0]
+        expect(d).to be_nil
+      end
+    end
+  end
 end

--- a/spec/unit/puppet/provider/keycloak_ldap_mapper/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_ldap_mapper/kcadm_spec.rb
@@ -63,6 +63,7 @@ describe Puppet::Type.type(:keycloak_ldap_mapper).provider(:kcadm) do
 
   describe 'destroy' do
     it 'should delete a realm' do
+      allow(@resource.provider).to receive(:id).and_return('b84ed8ed-a7b1-502f-83f6-90132e68adef')
       expect(@resource.provider).to receive(:kcadm).with('delete', 'components/b84ed8ed-a7b1-502f-83f6-90132e68adef', 'test')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
@@ -72,6 +73,7 @@ describe Puppet::Type.type(:keycloak_ldap_mapper).provider(:kcadm) do
 
   describe 'flush' do
     it 'should update a realm' do
+      allow(@resource.provider).to receive(:id).and_return('b84ed8ed-a7b1-502f-83f6-90132e68adef')
       temp = Tempfile.new('keycloak_component')
       allow(Tempfile).to receive(:new).with('keycloak_component').and_return(temp)
       expect(@resource.provider).to receive(:kcadm).with('update', 'components/b84ed8ed-a7b1-502f-83f6-90132e68adef', 'test', temp.path)

--- a/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
@@ -30,8 +30,8 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
     expect(resource[:resource_name]).to eq('foo')
   end
 
-  it 'should have id default to name-realm' do
-    expect(resource[:id]).to eq('b84ed8ed-a7b1-502f-83f6-90132e68adef')
+  it 'should not have id default' do
+    expect(resource[:id]).to be_nil
   end
 
   it 'should have realm' do

--- a/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
@@ -199,4 +199,20 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
     expect(rel.target.ref).to eq(resource.ref)
   end
 
+  [
+    :realm,
+    :ldap,
+  ].each do |property|
+    it "should require property #{property} when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { resource }.to raise_error(Puppet::Error, /You must provide a value for #{property}/)
+    end
+    it "should require property #{property} when ensure => absent" do
+      config.delete(property)
+      config[:ensure] = :absent
+      expect { resource }.to raise_error(Puppet::Error, /You must provide a value for #{property}/)
+    end
+  end
+
 end

--- a/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_mapper_spec.rb
@@ -95,9 +95,17 @@ describe Puppet::Type.type(:keycloak_ldap_mapper) do
     expect(resource[:always_read_value_from_ldap]).to eq(:false)
   end
 
+  it 'should have write_only with no default' do
+    expect(resource[:write_only]).to be_nil
+  end
+
+  it 'should have write_only default to false for full-name-ldap-mapper' do
+    config[:type] = 'full-name-ldap-mapper'
+    expect(resource[:write_only]).to be(:false)
+  end
+
   defaults = {
     :read_only => :true,
-    :write_only => :false
   }
 
   # Test basic properties


### PR DESCRIPTION
* Fix keycloak_ldap_mapper so that write_only only applies when type is full-name-ldap-mapper
* Better id handling for keycloak_ldap_mapper
* Move keycloak_ldap_mapper validations to be handled by the type and not the provider

Should fix issue where changing pre-installed components would fail without `id` specified.  Should fix #44 