### PR TITLE
Add option for service environment file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -182,7 +182,7 @@ class keycloak (
   Boolean $manage_sssd_config = true,
   Array $sssd_ifp_user_attributes = [],
   Boolean $restart_sssd = true,
-  Optional[String] $service_environment_file = undef
+  Optional[Stdlib::Absolutepath] $service_environment_file = undef
 ) inherits keycloak::params {
 
   $download_url = pick($package_url, "https://downloads.jboss.org/keycloak/${version}/keycloak-${version}.tar.gz")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,6 +131,8 @@
 #   user_attributes to define for SSSD ifp service
 # @param restart_sssd
 #   Boolean that determines if SSSD should be restarted
+# @param service_environment_file
+#   Path to the file with environment variables for the systemd service
 #
 class keycloak (
   String $version               = '4.2.1.Final',
@@ -180,6 +182,7 @@ class keycloak (
   Boolean $manage_sssd_config = true,
   Array $sssd_ifp_user_attributes = [],
   Boolean $restart_sssd = true,
+  Optional[String] $service_environment_file = undef
 ) inherits keycloak::params {
 
   $download_url = pick($package_url, "https://downloads.jboss.org/keycloak/${version}/keycloak-${version}.tar.gz")

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -5,6 +5,9 @@ After=network.target
 [Service]
 Type=idle
 #Environment="JAVA_OPTS=-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
+<% if !scope['keycloak::service_environment_file'].nil? -%>
+EnvironmentFile=<%= scope['keycloak::service_environment_file'] %>
+<% end -%>
 User=<%= scope['keycloak::user'] %>
 Group=<%= scope['keycloak::group'] %>
 ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=idle
 #Environment="JAVA_OPTS=-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
-<% if !scope['keycloak::service_environment_file'].nil? -%>
+<% if scope['keycloak::service_environment_file'] -%>
 EnvironmentFile=<%= scope['keycloak::service_environment_file'] %>
 <% end -%>
 User=<%= scope['keycloak::user'] %>


### PR DESCRIPTION
First, thanks for this great module! We're using the it for setting up a Keycloak instance that uses a custom extension. This extension needs configuring some environment variables, and the best seems to manage them in the `keycloak.service` file.

The pull request adds a parameter for including the `EnvironmentFile` option into the systemd service file, so it makes possible to configure environment variables for the Keycloak service.