### PR TITLE
Support managing realm's events config

### DIFF
--- a/lib/puppet/provider/keycloak_realm/kcadm.rb
+++ b/lib/puppet/provider/keycloak_realm/kcadm.rb
@@ -20,6 +20,19 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
     self.class.get_client_scopes(*args)
   end
 
+  def self.get_events_config(realm)
+    output = kcadm('get', 'events/config', realm)
+    Puppet.debug("#{realm} events/config: #{output}")
+    begin
+      data = JSON.parse(output)
+    rescue JSON::ParserError => e
+      Puppet.debug('Unable to parse output from kcadm get events/config')
+      data = {}
+    end
+    data.delete('enabledEventTypes')
+    data
+  end
+
   def self.instances
     realms = []
 
@@ -36,9 +49,14 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
       realm[:ensure] = :present
       realm[:id] = d['id']
       realm[:name] = d['realm']
+      events_config = get_events_config(d['realm'])
       type_properties.each do |property|
         next if [:default_client_scopes, :optional_client_scopes].include?(property)
-        value = d[camelize(property)]
+        if property.to_s =~ /events/
+          value = events_config[camelize(property)]
+        else
+          value = d[camelize(property)]
+        end
         if !!value == value
           value = value.to_s.to_sym
         end
@@ -63,11 +81,14 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
 
   def create
     data = {}
+    events_config = {}
     data[:id] = resource[:id]
     data[:realm] = resource[:name]
     type_properties.each do |property|
       next if [:default_client_scopes, :optional_client_scopes].include?(property)
-      if resource[property.to_sym]
+      if property.to_s =~ /events/
+        events_config[camelize(property)] = convert_property_value(resource[property.to_sym])
+      else resource[property.to_sym]
         data[camelize(property)] = convert_property_value(resource[property.to_sym])
       end
     end
@@ -130,6 +151,17 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
         raise Puppet::Error, "kcadm update realms/#{resource[:name]}/default-optional-client-scopes/#{scope_id}: #{e.message}"
       end
     end
+    if ! events_config.empty?
+      events_config_t = Tempfile.new('keycloak_events_config')
+      events_config_t.write(JSON.pretty_generate(events_config))
+      events_config_t.close
+      Puppet.debug(IO.read(events_config_t.path))
+      begin
+        kcadm('update', 'events/config', resource[:name], events_config_t.path)
+      rescue Exception => e
+        raise Puppet::Error, "kcadm update events config failed\nError message: #{e.message}"
+      end
+    end
     @property_hash[:ensure] = :present
   end
 
@@ -161,10 +193,15 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
   def flush
     if not @property_flush.empty?
       data = {}
+      events_config = {}
       type_properties.each do |property|
         next if [:default_client_scopes, :optional_client_scopes].include?(property)
         if @property_flush[property.to_sym] # || resource[property.to_sym]
-          data[camelize(property)] = convert_property_value(resource[property.to_sym])
+          if property.to_s =~ /events/
+            events_config[camelize(property)] = convert_property_value(resource[property.to_sym])
+          else
+            data[camelize(property)] = convert_property_value(resource[property.to_sym])
+          end
         end
       end
 
@@ -226,6 +263,17 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
           end
         rescue Exception => e
           raise Puppet::Error, "kcadm update realms/#{resource[:name]}/default-optional-client-scopes/#{scope_id}: #{e.message}"
+        end
+      end
+      if ! events_config.empty?
+        events_config_t = Tempfile.new('keycloak_events_config')
+        events_config_t.write(JSON.pretty_generate(events_config))
+        events_config_t.close
+        Puppet.debug(IO.read(events_config_t.path))
+        begin
+          kcadm('update', 'events/config', resource[:name], events_config_t.path)
+        rescue Exception => e
+          raise Puppet::Error, "kcadm update events config failed\nError message: #{e.message}"
         end
       end
     end

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -82,4 +82,31 @@ Manage Keycloak realms
   newproperty(:optional_client_scopes, :array_matching => :all, :parent => PuppetX::Keycloak::ArrayProperty) do
     desc 'Optional Client Scopes'
   end
+
+  newproperty(:events_enabled, :boolean => true) do
+    desc 'eventsEnabled'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newproperty(:events_expiration) do
+    desc 'eventsExpiration'
+  end
+
+  newproperty(:events_listeners, :array_matching => :all, :parent => PuppetX::Keycloak::ArrayProperty) do
+    desc 'eventsListeners'
+    defaultto ['jboss-logging']
+  end
+
+  newproperty(:admin_events_enabled, :boolean => true) do
+    desc 'adminEventsEnabled'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newproperty(:admin_events_details_enabled, :boolean => true) do
+    desc 'adminEventsDetailsEnabled'
+    newvalues(:true, :false)
+    defaultto :false
+  end
 end

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -41,6 +41,17 @@ describe 'keycloak_realm:' do
         expect(names).to include('phone')
       end
     end
+
+    it 'should have default events config' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get events/config -r test' do
+        data = JSON.parse(stdout)
+        expect(data['eventsEnabled']).to eq(false)
+        expect(data['eventsExpiration']).to be_nil
+        expect(data['eventsListeners']).to eq([ "jboss-logging" ])
+        expect(data['adminEventsEnabled']).to eq(false)
+        expect(data['adminEventsDetailsEnabled']).to eq(false)
+      end
+    end
   end
 
   context 'updates realm' do
@@ -54,6 +65,10 @@ describe 'keycloak_realm:' do
         ensure => 'present',
         remember_me => true,
         default_client_scopes => ['profile'],
+        events_enabled => true,
+        events_expiration => 2678400,
+        admin_events_enabled => true,
+        admin_events_details_enabled => true,
       }
       EOS
 
@@ -73,6 +88,17 @@ describe 'keycloak_realm:' do
         data = JSON.parse(stdout)
         names = data.map { |d| d['name'] }
         expect(names).to eq(['profile'])
+      end
+    end
+
+    it 'should have updated events config' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get events/config -r test' do
+        data = JSON.parse(stdout)
+        expect(data['eventsEnabled']).to eq(true)
+        expect(data['eventsExpiration']).to eq(2678400)
+        expect(data['eventsListeners']).to eq([ "jboss-logging" ])
+        expect(data['adminEventsEnabled']).to eq(true)
+        expect(data['adminEventsDetailsEnabled']).to eq(true)
       end
     end
   end

--- a/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
@@ -16,6 +16,8 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
       allow(@provider).to receive(:get_client_scopes).with('test', 'optional').and_return({'address' => '1cda5a52-aa2c-4b07-b620-30b703619581'})
       allow(@provider).to receive(:get_client_scopes).with('master', 'default').and_return({'profile' => '8a6759cb-3950-48a2-b29b-c2c06fc3379b'})
       allow(@provider).to receive(:get_client_scopes).with('master', 'optional').and_return({'address' => '1cda5a52-aa2c-4b07-b620-30b703619581'})
+      allow(@provider).to receive(:get_events_config).with('test').and_return({})
+      allow(@provider).to receive(:get_events_config).with('master').and_return({})
       expect(@provider.instances.length).to eq(2)
     end
 
@@ -25,6 +27,8 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
       allow(@provider).to receive(:get_client_scopes).with('test', 'optional').and_return({'address' => '1cda5a52-aa2c-4b07-b620-30b703619581'})
       allow(@provider).to receive(:get_client_scopes).with('master', 'default').and_return({'profile' => '8a6759cb-3950-48a2-b29b-c2c06fc3379b'})
       allow(@provider).to receive(:get_client_scopes).with('master', 'optional').and_return({'address' => '1cda5a52-aa2c-4b07-b620-30b703619581'})
+      allow(@provider).to receive(:get_events_config).with('test').and_return({})
+      allow(@provider).to receive(:get_events_config).with('master').and_return({})
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:enabled]).to eq(:true)
       expect(property_hash[:login_with_email_allowed]).to eq(:false)
@@ -58,8 +62,11 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
   describe 'create' do
     it 'should create a realm' do
       temp = Tempfile.new('keycloak_realm')
+      etemp = Tempfile.new('keycloak_events_config')
       allow(Tempfile).to receive(:new).with('keycloak_realm').and_return(temp)
+      allow(Tempfile).to receive(:new).with('keycloak_events_config').and_return(etemp)
       expect(@resource.provider).to receive(:kcadm).with('create', 'realms', nil, temp.path)
+      expect(@resource.provider).to receive(:kcadm).with('update', 'events/config', 'test', etemp.path)
       @resource.provider.create
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -36,6 +36,10 @@ describe Puppet::Type.type(:keycloak_realm) do
     :enabled => :true,
     :remember_me => :false,
     :login_with_email_allowed => :true,
+    :events_enabled => :false,
+    :events_listeners => ['jboss-logging'],
+    :admin_events_enabled => :false,
+    :admin_events_details_enabled => :false,
   }
 
   # Test basic properties
@@ -46,6 +50,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     :account_theme,
     :admin_theme,
     :email_theme,
+    :events_expiration,
   ].each do |p|
     it "should accept a #{p.to_s}" do
       config[p] = 'foo'
@@ -62,6 +67,9 @@ describe Puppet::Type.type(:keycloak_realm) do
   [
     :remember_me,
     :login_with_email_allowed,
+    :events_enabled,
+    :admin_events_enabled,
+    :admin_events_details_enabled,
   ].each do |p|
     it "should accept true for #{p.to_s}" do
       config[p] = true
@@ -96,6 +104,7 @@ describe Puppet::Type.type(:keycloak_realm) do
   [
     :default_client_scopes,
     :optional_client_scopes,
+    :events_listeners,
   ].each do |p|
     it "should accept array for #{p}" do
       config[p] = ['foo','bar']


### PR DESCRIPTION
Added properties to keycloak_realm:
* events_enabled
* events_expiration
* events_listeners
* admin_events_enabled
* admin_events_details_enabled