### PR TITLE
Fix handling of events config during updates

### DIFF
--- a/lib/puppet/provider/keycloak_realm/kcadm.rb
+++ b/lib/puppet/provider/keycloak_realm/kcadm.rb
@@ -197,11 +197,10 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, :parent => Puppet::Provider::
       type_properties.each do |property|
         next if [:default_client_scopes, :optional_client_scopes].include?(property)
         if @property_flush[property.to_sym] # || resource[property.to_sym]
-          if property.to_s =~ /events/
-            events_config[camelize(property)] = convert_property_value(resource[property.to_sym])
-          else
-            data[camelize(property)] = convert_property_value(resource[property.to_sym])
-          end
+          data[camelize(property)] = convert_property_value(resource[property.to_sym])
+        end
+        if property.to_s =~ /events/
+          events_config[camelize(property)] = convert_property_value(resource[property.to_sym])
         end
       end
 

--- a/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
@@ -85,8 +85,11 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
   describe 'flush' do
     it 'should update a realm' do
       temp = Tempfile.new('keycloak_realm')
+      etemp = Tempfile.new('keycloak_events_config')
       allow(Tempfile).to receive(:new).with('keycloak_realm').and_return(temp)
+      allow(Tempfile).to receive(:new).with('keycloak_events_config').and_return(etemp)
       expect(@resource.provider).to receive(:kcadm).with('update', 'realms/test', nil, temp.path)
+      expect(@resource.provider).to receive(:kcadm).with('update', 'events/config', 'test', etemp.path)
       @resource.provider.login_with_email_allowed = :false
       @resource.provider.flush
     end


### PR DESCRIPTION
All event configs must be specified during updates or some could be lost