### PR TITLE
Fix #78. Add clustered mode support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,8 @@
 #   Boolean that determines if SSSD should be restarted
 # @param service_environment_file
 #   Path to the file with environment variables for the systemd service
+# @param operating_mode
+#   Keycloak operating mode deployment
 #
 class keycloak (
   String $version               = '6.0.1',
@@ -228,6 +230,7 @@ class keycloak (
   Array $sssd_ifp_user_attributes = [],
   Boolean $restart_sssd = true,
   Optional[Stdlib::Absolutepath] $service_environment_file = undef,
+  Enum['standalone', 'clustered'] $operating_mode = 'standalone',
 ) {
 
   if ! $facts['os']['family'] in ['RedHat','Debian'] {

--- a/spec/acceptance/1_class_spec.rb
+++ b/spec/acceptance/1_class_spec.rb
@@ -21,6 +21,24 @@ describe 'keycloak class:' do
     end
   end
 
+  context 'default with clustered mode enable' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      class { 'keycloak':
+        operating_mode => 'clustered',
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('keycloak') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
   context 'default with mysql datasource' do
     it 'runs successfully' do
       pp = <<-EOS

--- a/templates/config.cli.erb
+++ b/templates/config.cli.erb
@@ -1,4 +1,8 @@
+<% if scope['keycloak::operating_mode'] == 'standalone'-%>
 embed-server
+<% elsif scope['keycloak::operating_mode'] == 'clustered'-%>
+embed-server --server-config=standalone-ha.xml
+<% end -%>
 <%- if scope['keycloak::proxy_https'] -%>
 if (result.proxy-address-forwarding != true) of /subsystem=undertow/server=default-server/http-listener=default:read-resource
 /subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=proxy-address-forwarding,value=true)

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -16,7 +16,11 @@ Environment="JAVA_OPTS=$JAVA_OPTS <%= scope['keycloak::service_java_opts'] %>"
 <% end -%>
 User=<%= scope['keycloak::user'] %>
 Group=<%= scope['keycloak::group'] %>
+<% if scope['keycloak::operating_mode'] == 'standalone'-%>
 ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>
+<% elsif scope['keycloak::operating_mode'] == 'clustered'-%>
+ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh --server-config=standalone-ha.xml -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>
+<% end -%>
 TimeoutStartSec=600
 TimeoutStopSec=600
 


### PR DESCRIPTION
According to: https://www.keycloak.org/docs/latest/server_installation/index.html#standalone-clustered-boot-script

> You use the same boot scripts to start Keycloak as you do in standalone mode. The difference is that you pass in an additional flag to point to the HA config file
> 
> To boot the server:
> $ .../bin/standalone.sh --server-config=standalone-ha.xml


Those were the only changes needed. About the tests, I would need your help for a more meaningful ones.

