### PR TITLE
Enable passing extra options to Keycloak in the systemd unit file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,8 @@
 #   Default is `true`.
 # @param service_java_opts
 #   Sets additional options to Java virtual machine environment variable.
+# @param service_extra_opts
+#   Additional options added to the end of the service command-line.
 # @param manage_user
 #   Defines if the module should manage the Linux user for Keycloak installation
 # @param user
@@ -178,6 +180,7 @@ class keycloak (
   Boolean $service_hasrestart   = true,
   Optional[Variant[String, Array]]
     $service_java_opts = undef,
+  Optional[String] $service_extra_opts = undef,
   Boolean $manage_user = true,
   String $user                  = 'keycloak',
   Stdlib::Absolutepath $user_shell = '/sbin/nologin',

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -17,9 +17,9 @@ Environment="JAVA_OPTS=$JAVA_OPTS <%= scope['keycloak::service_java_opts'] %>"
 User=<%= scope['keycloak::user'] %>
 Group=<%= scope['keycloak::group'] %>
 <% if scope['keycloak::operating_mode'] == 'standalone'-%>
-ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>
+ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %><% if scope['keycloak::service_extra_opts'] -%> <%= scope['keycloak::service_extra_opts'] -%><% end %>
 <% elsif scope['keycloak::operating_mode'] == 'clustered'-%>
-ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh --server-config=standalone-ha.xml -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %>
+ExecStart=<%= scope['keycloak::install_base'] %>/bin/standalone.sh --server-config=standalone-ha.xml -b 0.0.0.0 -Djboss.http.port=<%= scope['keycloak::http_port'] %><% if scope['keycloak::service_extra_opts'] -%> <%= scope['keycloak::service_extra_opts'] -%><% end %>
 <% end -%>
 TimeoutStartSec=600
 TimeoutStopSec=600


### PR DESCRIPTION
This allows passing arbitrary command-line options as a string to standalone.sh in the systemd unit file.