### PR TITLE
Allow managing Keycloak installation from outside this module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,11 @@
 # @example
 #   include ::keycloak
 #
+# @param manage_install
+#   Install Keycloak from upstream Keycloak tarball.
+#   Set to false to manage installation of Keycloak outside
+#   this module and set $install_dir and $version to match.
+#   Defaults to true.
 # @param version
 #   Version of Keycloak to install and manage.
 # @param package_url
@@ -169,6 +174,7 @@
 #   Keycloak operating mode deployment
 #
 class keycloak (
+  Boolean $manage_install       = true,
   String $version               = '6.0.1',
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]]
     $package_url                = undef,


### PR DESCRIPTION
Example usage from a profile with a package that installs Keycloak to /opt/keycloak-7.0.0 from an apt (or yum) repository:

```
package { 'keycloak':
  ensure => 'present',
  before => Class['::keycloak'],
}
class { 'keycloak':
  manage_install => false,
  version        => '7.0.0',
}
```
Owner and group of the files in the package are assumed _not_ to be correct, for example "root:root". Therefore are recursive chown is done to the install directory. That way the user and group the package sets does not have to be kept in sync with $::keycloak::user and $::keycloak::group in this module.

That said, I can handle the chowning in a package post-install script as well, if that seems more reasonable to you.