### PR TITLE
Change how install_dir is defined, default behavior remains the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,15 +283,15 @@ The keycloak_api type can be used to define how this module's types access the K
 
  ```puppet
 keycloak_api { 'keycloak'
-  install_base => '/opt/keycloak',
-  server       => 'http://localhost:8080/auth',
-  realm        => 'master',
-  user         => 'admin',
-  password     => 'changeme',
+  install_dir => '/opt/keycloak',
+  server     => 'http://localhost:8080/auth',
+  realm      => 'master',
+  user       => 'admin',
+  password   => 'changeme',
 }
 ```
 
-The path for `install_base` will be joined with `bin/kcadm.sh` to produce the full path to `kcadm.sh`.
+The path for `install_dir` will be joined with `bin/kcadm.sh` to produce the full path to `kcadm.sh`.
 
 ## Reference
 

--- a/lib/puppet/provider/keycloak_api.rb
+++ b/lib/puppet/provider/keycloak_api.rb
@@ -8,7 +8,7 @@ class Puppet::Provider::KeycloakAPI < Puppet::Provider
   # Unused but defined anyways
   commands kcadm_wrapper: '/opt/keycloak/bin/kcadm-wrapper.sh'
 
-  @install_base = nil
+  @install_dir = nil
   @server = nil
   @realm = nil
   @user = nil
@@ -16,7 +16,7 @@ class Puppet::Provider::KeycloakAPI < Puppet::Provider
   @use_wrapper = true
 
   class << self
-    attr_accessor :install_base
+    attr_accessor :install_dir
     attr_accessor :server
     attr_accessor :realm
     attr_accessor :user
@@ -79,7 +79,7 @@ class Puppet::Provider::KeycloakAPI < Puppet::Provider
         '--user', user,
         '--password', password
       ]
-      cmd = [File.join(install_base, 'bin/kcadm.sh')] + arguments + auth_arguments
+      cmd = [File.join(install_dir, 'bin/kcadm.sh')] + arguments + auth_arguments
     else
       cmd = [kcadm_wrapper] + arguments
     end

--- a/lib/puppet/type/keycloak_api.rb
+++ b/lib/puppet/type/keycloak_api.rb
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:keycloak_api) do
   Type that configures API connection parameters for other keycloak types that use the Keycloak API.
   @example Define API access
     keycloak_api { 'keycloak'
-      install_base => '/opt/keycloak',
+      install_dir  => '/opt/keycloak',
       server       => 'http://localhost:8080/auth',
       realm        => 'master',
       user         => 'admin',
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:keycloak_api) do
     desc 'Keycloak API config'
   end
 
-  newparam(:install_base) do
+  newparam(:install_dir) do
     desc 'Install location of Keycloak'
   end
 
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:keycloak_api) do
       :keycloak_realm,
     ].each do |res_type|
       provider_class = Puppet::Type.type(res_type).provider(:kcadm)
-      provider_class.install_base = self[:install_base]
+      provider_class.install_dir = self[:install_dir]
       provider_class.server = self[:server]
       provider_class.realm = self[:realm]
       provider_class.user = self[:user]

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@ class keycloak::config {
 
   file { '/opt/keycloak':
     ensure => 'link',
-    target => $keycloak::install_base
+    target => $keycloak::install_base,
   }
 
   # Template uses:

--- a/manifests/datasource/mysql.pp
+++ b/manifests/datasource/mysql.pp
@@ -6,7 +6,7 @@ class keycloak::datasource::mysql {
 
   $jar_source = pick($keycloak::datasource_jar_source, $keycloak::mysql_jar_source)
   $module_source = pick($keycloak::datasource_module_source, 'puppet:///modules/keycloak/database/mysql/module.xml')
-  $module_dir = "${keycloak::install_dir}/keycloak-${keycloak::version}/modules/system/layers/keycloak/com/mysql/jdbc/main"
+  $module_dir = "${keycloak::install_base}/modules/system/layers/keycloak/com/mysql/jdbc/main"
 
   if $keycloak::datasource_package {
     ensure_packages([$keycloak::datasource_package])

--- a/manifests/datasource/oracle.pp
+++ b/manifests/datasource/oracle.pp
@@ -6,7 +6,7 @@ class keycloak::datasource::oracle {
   assert_private()
 
   $module_source = pick($keycloak::datasource_module_source, 'puppet:///modules/keycloak/database/oracle/module.xml')
-  $module_dir = "${keycloak::install_dir}/keycloak-${keycloak::version}/modules/system/layers/keycloak/org/oracle/main"
+  $module_dir = "${keycloak::install_base}/modules/system/layers/keycloak/org/oracle/main"
 
   exec { "mkdir -p ${module_dir}":
     path    => '/usr/bin:/bin',

--- a/manifests/datasource/postgresql.pp
+++ b/manifests/datasource/postgresql.pp
@@ -6,7 +6,7 @@ class keycloak::datasource::postgresql {
 
   $jar_source = pick($keycloak::datasource_jar_source, $keycloak::postgresql_jar_source)
   $module_source = pick($keycloak::datasource_module_source, 'puppet:///modules/keycloak/database/postgresql/module.xml')
-  $module_dir = "${keycloak::install_dir}/keycloak-${keycloak::version}/modules/system/layers/keycloak/org/postgresql/main"
+  $module_dir = "${keycloak::install_base}/modules/system/layers/keycloak/org/postgresql/main"
 
   include ::postgresql::lib::java
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 # @param manage_install
 #   Install Keycloak from upstream Keycloak tarball.
 #   Set to false to manage installation of Keycloak outside
-#   this module and set $install_dir and $version to match.
+#   this module and set $install_dir to match.
 #   Defaults to true.
 # @param version
 #   Version of Keycloak to install and manage.
@@ -14,8 +14,8 @@
 #   URL of the Keycloak download.
 #   Default is based on version.
 # @param install_dir
-#   Parent directory of where to install Keycloak.
-#   Default is `/opt`.
+#   The directory of where to install Keycloak.
+#   Default is `/opt/keycloak-${version}`.
 # @param service_name
 #   Keycloak service name.
 #   Default is `keycloak`.
@@ -189,7 +189,7 @@ class keycloak (
   String $version               = '6.0.1',
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]]
     $package_url                = undef,
-  Stdlib::Absolutepath $install_dir = '/opt',
+  Optional[Stdlib::Absolutepath] $install_dir = undef,
   String $service_name          = 'keycloak',
   String $service_ensure        = 'running',
   Boolean $service_enable       = true,
@@ -315,7 +315,7 @@ class keycloak (
     }
   }
 
-  $install_base = "${keycloak::install_dir}/keycloak-${keycloak::version}"
+  $install_base = pick($install_dir, "/opt/keycloak-${keycloak::version}")
 
   include ::java
   contain 'keycloak::install'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,10 +21,8 @@ class keycloak::install {
     }
   }
 
-  $install_base = "${keycloak::install_dir}/keycloak-${keycloak::version}"
-
   if $::keycloak::manage_install {
-    file { $install_base:
+    file { $::keycloak::install_base:
       ensure => 'directory',
       owner  => $keycloak::user,
       group  => $keycloak::group,
@@ -34,10 +32,10 @@ class keycloak::install {
       ensure          => 'present',
       extract         => true,
       path            => "/tmp/keycloak-${keycloak::version}.tar.gz",
-      extract_path    => $install_base,
+      extract_path    => $::keycloak::install_base,
       extract_command => 'tar xfz %s --strip-components=1',
       source          => $keycloak::download_url,
-      creates         => "${install_base}/bin",
+      creates         => "${::keycloak::install_base}/bin",
       cleanup         => true,
       user            => $keycloak::user,
       group           => $keycloak::group,
@@ -45,8 +43,8 @@ class keycloak::install {
   } else {
     # Set permissions properly when using a package
     exec { 'ensure-keycloak-dir-owner':
-      command => "chown -R ${::keycloak::user}:${::keycloak::group} ${install_base}",
-      unless  => "test `stat -c %U ${install_base}` = ${::keycloak::user}",
+      command => "chown -R ${::keycloak::user}:${::keycloak::group} ${::keycloak::install_base}",
+      unless  => "test `stat -c %U ${::keycloak::install_base}` = ${::keycloak::user}",
       path    => ['/bin','/usr/bin'],
     }
   }

--- a/spec/acceptance/99_keycloak_api_spec.rb
+++ b/spec/acceptance/99_keycloak_api_spec.rb
@@ -18,7 +18,7 @@ describe 'keycloak_api:', if: RSpec.configuration.keycloak_full do
     it 'runs successfully' do
       pp = <<-EOS
       keycloak_api { 'keycloak':
-        install_base => '/opt/keycloak',
+        install_dir => '/opt/keycloak',
       }
       keycloak_realm { 'test2': ensure => 'present' }
       EOS
@@ -40,7 +40,7 @@ describe 'keycloak_api:', if: RSpec.configuration.keycloak_full do
     it 'runs successfully' do
       pp = <<-EOS
       keycloak_api { 'keycloak':
-        install_base => '/opt/keycloak',
+        install_dir => '/opt/keycloak',
       }
       keycloak_realm { 'test2':
         ensure => 'present',


### PR DESCRIPTION
The default for `install_dir` changes from `/opt` to `/opt/keycloak-$version`.