### PR TITLE
Add support for managing client attributes

### DIFF
--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -120,6 +120,13 @@ Manage Keycloak clients
     defaultto []
   end
 
+  newproperty(:attributes) do
+    desc 'attributes'
+    validate do |attributes|
+      raise('Property attributes must be a hash') unless attributes.is_a?(Hash)
+    end
+  end
+
   autorequire(:keycloak_client_scope) do
     requires = []
     catalog.resources.each do |resource|

--- a/spec/unit/puppet/type/keycloak_client_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_spec.rb
@@ -142,6 +142,22 @@ describe Puppet::Type.type(:keycloak_client) do
     end
   end
 
+  describe 'hash properties' do
+    # Hash properties
+    [
+      :attributes,
+    ].each do |p|
+      it "should accept hash for #{p}" do
+        config[p] = { foo: 'bar' }
+        expect(resource[p]).to eq(foo: 'bar')
+      end
+      next unless defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
+  end
+
   it 'autorequires keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(name: 'keycloak')
     catalog = Puppet::Resource::Catalog.new


### PR DESCRIPTION
Due to the way provider is implemented it is only possible to add attributes and
modify their values, not to get rid of them once they're set (manually or with Puppet).