### PR TITLE
Change JAVA_OPTS behavior for Keycloak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
   - gem --version
   - bundle -v
 script:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,26 +68,26 @@ class keycloak::config {
 
   create_resources('keycloak::truststore::host', $keycloak::truststore_hosts)
 
-  if $keycloak::service_java_opts {
+  if $keycloak::java_opts {
     $java_opts_ensure = 'present'
   } else {
     $java_opts_ensure = 'absent'
   }
 
-  if $keycloak::service_java_opts =~ Array {
-    $service_java_opts = join($keycloak::service_java_opts, ' ')
+  if $keycloak::java_opts =~ Array {
+    $java_opts = join($keycloak::java_opts, ' ')
   } else {
-    $service_java_opts = $keycloak::service_java_opts
+    $java_opts = $keycloak::java_opts
   }
-  if $keycloak::service_java_opts_append {
-    $java_opts = "\$JAVA_OPTS ${service_java_opts}"
+  if $keycloak::java_opts_append {
+    $_java_opts = "\$JAVA_OPTS ${java_opts}"
   } else {
-    $java_opts = $service_java_opts
+    $_java_opts = $java_opts
   }
   file_line { 'standalone.conf-JAVA_OPTS':
     ensure => $java_opts_ensure,
     path   => "${keycloak::install_base}/bin/standalone.conf",
-    line   => "JAVA_OPTS=\"${java_opts}\"",
+    line   => "JAVA_OPTS=\"${_java_opts}\"",
     match  => '^JAVA_OPTS=',
     notify => Class['keycloak::service'],
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,4 +68,22 @@ class keycloak::config {
 
   create_resources('keycloak::truststore::host', $keycloak::truststore_hosts)
 
+  if $keycloak::service_java_opts {
+    $java_opts_ensure = 'present'
+  } else {
+    $java_opts_ensure = 'absent'
+  }
+
+  if $keycloak::service_java_opts =~ Array {
+    $service_java_opts = join($keycloak::service_java_opts, ' ')
+  } else {
+    $service_java_opts = $keycloak::service_java_opts
+  }
+  file_line { 'standalone.conf-JAVA_OPTS':
+    ensure => $java_opts_ensure,
+    path   => "${keycloak::install_base}/bin/standalone.conf",
+    line   => "JAVA_OPTS=\"\$JAVA_OPTS ${service_java_opts}\"",
+    match  => '^JAVA_OPTS=',
+    notify => Class['keycloak::service'],
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -79,10 +79,15 @@ class keycloak::config {
   } else {
     $service_java_opts = $keycloak::service_java_opts
   }
+  if $keycloak::service_java_opts_append {
+    $java_opts = "\$JAVA_OPTS ${service_java_opts}"
+  } else {
+    $java_opts = $service_java_opts
+  }
   file_line { 'standalone.conf-JAVA_OPTS':
     ensure => $java_opts_ensure,
     path   => "${keycloak::install_base}/bin/standalone.conf",
-    line   => "JAVA_OPTS=\"\$JAVA_OPTS ${service_java_opts}\"",
+    line   => "JAVA_OPTS=\"${java_opts}\"",
     match  => '^JAVA_OPTS=',
     notify => Class['keycloak::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,6 +196,7 @@ class keycloak (
   Stdlib::IP::Address $service_bind_address = '0.0.0.0',
   Optional[Variant[String, Array]]
     $service_java_opts = undef,
+  Boolean $service_java_opts_append = true,
   Optional[String] $service_extra_opts = undef,
   Boolean $manage_user = true,
   String $user                  = 'keycloak',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,8 +34,10 @@
 # @param service_bind_address
 #   Bind address for Keycloak service.
 #   Default is '0.0.0.0'.
-# @param service_java_opts
+# @param java_opts
 #   Sets additional options to Java virtual machine environment variable.
+# @param java_opts_append
+#   Determine if $JAVA_OPTS should be appended to when setting `java_opts` parameter
 # @param service_extra_opts
 #   Additional options added to the end of the service command-line.
 # @param manage_user
@@ -194,9 +196,8 @@ class keycloak (
   Boolean $service_hasstatus    = true,
   Boolean $service_hasrestart   = true,
   Stdlib::IP::Address $service_bind_address = '0.0.0.0',
-  Optional[Variant[String, Array]]
-    $service_java_opts = undef,
-  Boolean $service_java_opts_append = true,
+  Optional[Variant[String, Array]] $java_opts = undef,
+  Boolean $java_opts_append = true,
   Optional[String] $service_extra_opts = undef,
   Boolean $manage_user = true,
   String $user                  = 'keycloak',

--- a/spec/acceptance/1_class_spec.rb
+++ b/spec/acceptance/1_class_spec.rb
@@ -93,13 +93,14 @@ describe 'keycloak class:' do
     end
   end
 
-  context 'default with proxy_https' do
+  context 'changes to defaults' do
     it 'runs successfully' do
       pp = <<-EOS
       include mysql::server
       class { 'keycloak':
         datasource_driver => 'mysql',
         proxy_https       => true,
+        service_java_opts => '-Xmx512m -Xms512m',
       }
       EOS
 

--- a/spec/acceptance/1_class_spec.rb
+++ b/spec/acceptance/1_class_spec.rb
@@ -100,7 +100,7 @@ describe 'keycloak class:' do
       class { 'keycloak':
         datasource_driver => 'mysql',
         proxy_https       => true,
-        service_java_opts => '-Xmx512m -Xms64m',
+        java_opts         => '-Xmx512m -Xms64m',
       }
       EOS
 

--- a/spec/acceptance/1_class_spec.rb
+++ b/spec/acceptance/1_class_spec.rb
@@ -100,7 +100,7 @@ describe 'keycloak class:' do
       class { 'keycloak':
         datasource_driver => 'mysql',
         proxy_https       => true,
-        service_java_opts => '-Xmx512m -Xms512m',
+        service_java_opts => '-Xmx512m -Xms64m',
       }
       EOS
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -147,8 +147,8 @@ describe 'keycloak' do
           end
         end
 
-        context 'when service_java_opts defined' do
-          let(:params) { { service_java_opts: '-Xmx512m -Xms64m' } }
+        context 'when java_opts defined' do
+          let(:params) { { java_opts: '-Xmx512m -Xms64m' } }
 
           it do
             is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
@@ -160,8 +160,8 @@ describe 'keycloak' do
             )
           end
 
-          context 'when service_java_opts_append is false' do
-            let(:params) { { service_java_opts: '-Xmx512m -Xms64m', service_java_opts_append: false } }
+          context 'when java_opts_append is false' do
+            let(:params) { { java_opts: '-Xmx512m -Xms64m', java_opts_append: false } }
 
             it do
               is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -129,11 +129,49 @@ describe 'keycloak' do
           )
         end
 
+        it do
+          is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
+            ensure: 'absent',
+            path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+            line: 'JAVA_OPTS="$JAVA_OPTS "',
+            match: '^JAVA_OPTS=',
+            notify: 'Class[Keycloak::Service]',
+          )
+        end
+
         context 'when tech_preview_features defined' do
           let(:params) { { tech_preview_features: ['account_api'] } }
 
           it do
             verify_exact_file_contents(catalogue, '/opt/keycloak-6.0.1/standalone/configuration/profile.properties', ['feature.account_api=enabled'])
+          end
+        end
+
+        context 'when service_java_opts defined' do
+          let(:params) { { service_java_opts: '-Xmx512m -Xms64m' } }
+
+          it do
+            is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
+              ensure: 'present',
+              path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+              line: 'JAVA_OPTS="$JAVA_OPTS -Xmx512m -Xms64m"',
+              match: '^JAVA_OPTS=',
+              notify: 'Class[Keycloak::Service]',
+            )
+          end
+
+          context 'when service_java_opts_append is false' do
+            let(:params) { { service_java_opts: '-Xmx512m -Xms64m', service_java_opts_append: false } }
+
+            it do
+              is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
+                ensure: 'present',
+                path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+                line: 'JAVA_OPTS="-Xmx512m -Xms64m"',
+                match: '^JAVA_OPTS=',
+                notify: 'Class[Keycloak::Service]',
+              )
+            end
           end
         end
       end

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -9,9 +9,9 @@ EnvironmentFile=<%= scope['keycloak::service_environment_file'] %>
 <% end -%>
 <% if scope['keycloak::service_java_opts'] -%>
 <% if scope['keycloak::server_java_opts'].is_a?(Array) -%>
-Environment="JAVA_OPTS=$JAVA_OPTS <%= scope['keycloak::service_java_opts'].join(' ') %>"
+Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'].join(' ') %>"
 <% else %>
-Environment="JAVA_OPTS=$JAVA_OPTS <%= scope['keycloak::service_java_opts'] %>"
+Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'] %>"
 <% end -%>
 <% end -%>
 User=<%= scope['keycloak::user'] %>

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -7,13 +7,6 @@ Type=idle
 <% if scope['keycloak::service_environment_file'] -%>
 EnvironmentFile=<%= scope['keycloak::service_environment_file'] %>
 <% end -%>
-<% if scope['keycloak::service_java_opts'] -%>
-<% if scope['keycloak::service_java_opts'].is_a?(Array) -%>
-Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'].join(' ') %>"
-<% else %>
-Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'] %>"
-<% end -%>
-<% end -%>
 User=<%= scope['keycloak::user'] %>
 Group=<%= scope['keycloak::group'] %>
 <% if scope['keycloak::operating_mode'] == 'standalone'-%>

--- a/templates/keycloak.service.erb
+++ b/templates/keycloak.service.erb
@@ -8,7 +8,7 @@ Type=idle
 EnvironmentFile=<%= scope['keycloak::service_environment_file'] %>
 <% end -%>
 <% if scope['keycloak::service_java_opts'] -%>
-<% if scope['keycloak::server_java_opts'].is_a?(Array) -%>
+<% if scope['keycloak::service_java_opts'].is_a?(Array) -%>
 Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'].join(' ') %>"
 <% else %>
 Environment="JAVA_OPTS=<%= scope['keycloak::service_java_opts'] %>"


### PR DESCRIPTION
Fixes #104

No longer set `JAVA_OPTS` inside the systemd unit file. Instead append to `JAVA_OPTS` inside `bin/standalone.conf`.

Add `java_opts_append` parameter

BREAKING:
* Rename `service_java_opts` parameter to `java_opts`