### PR TITLE
Change default Keycloak version to 8.0.1

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -20,68 +20,68 @@
       collection: puppet5
       extra_envs:
         - BEAKER_keycloak_full: yes
-    - set: centos-7
-      collection: puppet5
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
-        - BEAKER_keycloak_full: yes
-    - set: centos-7
-      collection: puppet6
-      extra_envs:
-        - BEAKER_keycloak_full: yes
+#    - set: centos-7
+#      collection: puppet5
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
+#        - BEAKER_keycloak_full: yes
     - set: centos-7
       collection: puppet6
       extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
         - BEAKER_keycloak_full: yes
+#    - set: centos-7
+#      collection: puppet6
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
+#        - BEAKER_keycloak_full: yes
     - set: centos-8
       collection: puppet5
-    - set: centos-8
-      collection: puppet5
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
-    - set: centos-8
-      collection: puppet6
+#    - set: centos-8
+#      collection: puppet5
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: centos-8
       collection: puppet6
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
+#    - set: centos-8
+#      collection: puppet6
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: debian-9
       collection: puppet5
-    - set: debian-9
-      collection: puppet5
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
-    - set: debian-9
-      collection: puppet6
+#    - set: debian-9
+#      collection: puppet5
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: debian-9
       collection: puppet6
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
+#    - set: debian-9
+#      collection: puppet6
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: debian-10
       collection: puppet5
-    - set: debian-10
-      collection: puppet5
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
-    - set: debian-10
-      collection: puppet6
+#    - set: debian-10
+#      collection: puppet5
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: debian-10
       collection: puppet6
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
+#    - set: debian-10
+#      collection: puppet6
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: ubuntu-1804
       collection: puppet5
-    - set: ubuntu-1804
-      collection: puppet5
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
-    - set: ubuntu-1804
-      collection: puppet6
+#    - set: ubuntu-1804
+#      collection: puppet5
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
     - set: ubuntu-1804
       collection: puppet6
-      extra_envs:
-        - BEAKER_keycloak_version: 7.0.0
+#    - set: ubuntu-1804
+#      collection: puppet6
+#      extra_envs:
+#        - BEAKER_keycloak_version: 7.0.0
   user: treydock
   secure: "u4N3WOhiO4X0mmEF7I+ARGpcw4Wrmt1xA8cmG2Qlnvr+r3c7RgWfc6GoabLicGKoN/OqVPD1b6lXJ+Xrg8VAJb9NmFjXYkowbTYgyyPsx6fSIshaquThkrEUsaF1C5hWx1rADXCz8hkpvX537xye/uKQlvDjwHyHaJWu3rpCfsDApYwYZhIkKtsSk2hOlcX9jfI1LE/H6YYo44uRBxg2lyUusScJQcDe023mBYOOSet3C4w4UpPBqR0mu9XvjJHk0KJzBE2Jk6g7W+02/ZkVW9qDXh70mCE562uQN/CE8rjcM5V1M6L69YzG5rv0LSuV4rnrjNtkNz6GZPDKIpuwOLEkA0M+jBr+F2d4tPHyMVDGLQHIIl5/TxXU2A9+gDe9yZFeZ7KEOSkkYfEgKgHcPHMZQJhs7Xkj2ab+F3AFjrSbjWngX892NQXp9XK4EXBZzogdsEp+wHULc9ybb9BKUNS0FIbCOjJoqBuwe7Is8vfVQ+OXAxVnP1POEoAgmgD3gQVHtedBAYrT7Ge+uxILua+KaPYkxBh/Cg9TYYSJeO/y0LH8pV3zSOQ3oU3MGZRbZrLbNkFAq9sYu3Klw52NEgfgXNRaE5AIpC0Tjf/BHZuaGGPyZML4A14tctwzFCFmG8SXkN2fFtpS5LAfLzbizi2KecPMyEjSpHJATJ/6HuQ="
 .gitlab-ci.yml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,25 +34,7 @@ matrix:
     -
       bundler_args: --with system_tests
       dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=centos-7 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1 BEAKER_keycloak_full=true
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=centos-7 BEAKER_TESTMODE=apply BEAKER_keycloak_full=true
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=centos-7 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1 BEAKER_keycloak_full=true
       rvm: 2.5.3
       script: bundle exec rake beaker
       services: docker
@@ -70,25 +52,7 @@ matrix:
     -
       bundler_args: --with system_tests
       dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=centos-8 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=centos-8 BEAKER_TESTMODE=apply
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=centos-8 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
       rvm: 2.5.3
       script: bundle exec rake beaker
       services: docker
@@ -106,25 +70,7 @@ matrix:
     -
       bundler_args: --with system_tests
       dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=debian-9 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-9 BEAKER_TESTMODE=apply
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-9 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
       rvm: 2.5.3
       script: bundle exec rake beaker
       services: docker
@@ -142,25 +88,7 @@ matrix:
     -
       bundler_args: --with system_tests
       dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=debian-10 BEAKER_TESTMODE=apply BEAKER_keycloak_version=7.0.0
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-10 BEAKER_TESTMODE=apply
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=debian-10 BEAKER_TESTMODE=apply BEAKER_keycloak_version=7.0.0
       rvm: 2.5.3
       script: bundle exec rake beaker
       services: docker
@@ -178,25 +106,7 @@ matrix:
     -
       bundler_args: --with system_tests
       dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_set=ubuntu-1804 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=ubuntu-1804 BEAKER_TESTMODE=apply
-      rvm: 2.5.3
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: xenial
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=ubuntu-1804 BEAKER_TESTMODE=apply BEAKER_keycloak_version=8.0.1
       rvm: 2.5.3
       script: bundle exec rake beaker
       services: docker

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The keycloak module allows easy installation and management of Keycloak.
 | ---------------- | ------------------------------- |
 | 3.x              | 2.x                             |
 | 4.x - 6.x        | 3.x                             |
-| 6.x - 7.x        | 4.x - 5.x                       |
+| 6.x - 8.x        | 4.x - 5.x                       |
+| 8.x              | 6.x                             |
 
 
 ## Usage

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,7 +186,7 @@
 #
 class keycloak (
   Boolean $manage_install       = true,
-  String $version               = '6.0.1',
+  String $version               = '8.0.1',
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]]
     $package_url                = undef,
   Stdlib::Absolutepath $install_dir = '/opt',

--- a/metadata.json
+++ b/metadata.json
@@ -81,5 +81,5 @@
   ],
   "pdk-version": "1.14.1",
   "template-url": "https://github.com/treydock/pdk-templates.git#master",
-  "template-ref": "heads/master-0-gf5c98be"
+  "template-ref": "heads/master-0-g64aa7a6"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,7 @@ describe 'keycloak' do
       let(:facts) do
         facts.merge(concat_basedir: '/dne')
       end
+      let(:version) { '8.0.1' }
 
       case facts[:osfamily]
       when %r{RedHat}
@@ -77,7 +78,7 @@ describe 'keycloak' do
         it do
           is_expected.to contain_file('kcadm-wrapper.sh').only_with(
             ensure: 'file',
-            path: '/opt/keycloak-6.0.1/bin/kcadm-wrapper.sh',
+            path: "/opt/keycloak-#{version}/bin/kcadm-wrapper.sh",
             owner: 'keycloak',
             group: 'keycloak',
             mode: '0750',
@@ -88,13 +89,13 @@ describe 'keycloak' do
 
         it do
           is_expected.to contain_exec('create-keycloak-admin')
-            .with(command: '/opt/keycloak-6.0.1/bin/add-user-keycloak.sh --user admin --password changeme --realm master && touch /opt/keycloak-6.0.1/.create-keycloak-admin-h2',
-                  creates: '/opt/keycloak-6.0.1/.create-keycloak-admin-h2',
+            .with(command: "/opt/keycloak-#{version}/bin/add-user-keycloak.sh --user admin --password changeme --realm master && touch /opt/keycloak-#{version}/.create-keycloak-admin-h2",
+                  creates: "/opt/keycloak-#{version}/.create-keycloak-admin-h2",
                   notify: 'Class[Keycloak::Service]')
         end
 
         it do
-          is_expected.to contain_file('/opt/keycloak-6.0.1/standalone/configuration').only_with(
+          is_expected.to contain_file("/opt/keycloak-#{version}/standalone/configuration").only_with(
             ensure: 'directory',
             owner: 'keycloak',
             group: 'keycloak',
@@ -103,7 +104,7 @@ describe 'keycloak' do
         end
 
         it do
-          is_expected.to contain_file('/opt/keycloak-6.0.1/standalone/configuration/profile.properties').only_with(
+          is_expected.to contain_file("/opt/keycloak-#{version}/standalone/configuration/profile.properties").only_with(
             ensure: 'file',
             owner: 'keycloak',
             group: 'keycloak',
@@ -114,11 +115,11 @@ describe 'keycloak' do
         end
 
         it do
-          verify_exact_file_contents(catalogue, '/opt/keycloak-6.0.1/standalone/configuration/profile.properties', [])
+          verify_exact_file_contents(catalogue, "/opt/keycloak-#{version}/standalone/configuration/profile.properties", [])
         end
 
         it do
-          is_expected.to contain_file('/opt/keycloak-6.0.1/config.cli').only_with(
+          is_expected.to contain_file("/opt/keycloak-#{version}/config.cli").only_with(
             ensure: 'file',
             owner: 'keycloak',
             group: 'keycloak',
@@ -132,7 +133,7 @@ describe 'keycloak' do
         it do
           is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
             ensure: 'absent',
-            path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+            path: "/opt/keycloak-#{version}/bin/standalone.conf",
             line: 'JAVA_OPTS="$JAVA_OPTS "',
             match: '^JAVA_OPTS=',
             notify: 'Class[Keycloak::Service]',
@@ -143,7 +144,7 @@ describe 'keycloak' do
           let(:params) { { tech_preview_features: ['account_api'] } }
 
           it do
-            verify_exact_file_contents(catalogue, '/opt/keycloak-6.0.1/standalone/configuration/profile.properties', ['feature.account_api=enabled'])
+            verify_exact_file_contents(catalogue, "/opt/keycloak-#{version}/standalone/configuration/profile.properties", ['feature.account_api=enabled'])
           end
         end
 
@@ -153,7 +154,7 @@ describe 'keycloak' do
           it do
             is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
               ensure: 'present',
-              path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+              path: "/opt/keycloak-#{version}/bin/standalone.conf",
               line: 'JAVA_OPTS="$JAVA_OPTS -Xmx512m -Xms64m"',
               match: '^JAVA_OPTS=',
               notify: 'Class[Keycloak::Service]',
@@ -166,7 +167,7 @@ describe 'keycloak' do
             it do
               is_expected.to contain_file_line('standalone.conf-JAVA_OPTS').with(
                 ensure: 'present',
-                path: '/opt/keycloak-6.0.1/bin/standalone.conf',
+                path: "/opt/keycloak-#{version}/bin/standalone.conf",
                 line: 'JAVA_OPTS="-Xmx512m -Xms64m"',
                 match: '^JAVA_OPTS=',
                 notify: 'Class[Keycloak::Service]',

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |c|
   c.add_setting :keycloak_version
-  c.keycloak_version = (ENV['BEAKER_keycloak_version'] || '6.0.1')
+  c.keycloak_version = (ENV['BEAKER_keycloak_version'] || '8.0.1')
   c.add_setting :keycloak_full
   c.keycloak_full = (ENV['BEAKER_keycloak_full'] == 'true' || ENV['BEAKER_keycloak_full'] == 'yes')
 end


### PR DESCRIPTION
**Important** If you wish to remain on non-default version, you must set the `version` parameter for `keycloak` class.