### PR TITLE
Fix problem with keycloak admin user creation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,9 +25,10 @@ class keycloak::config {
   $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master"
   $_add_user_keycloak_state = "${keycloak::install_base}/.create-keycloak-admin-${keycloak::datasource_driver}"
   exec { 'create-keycloak-admin':
-    command => "${_add_user_keycloak_cmd} ${_add_user_keycloak_args} && touch ${_add_user_keycloak_state}",
-    creates => $_add_user_keycloak_state,
-    notify  => Class['keycloak::service'],
+    command     => "${_add_user_keycloak_cmd} ${_add_user_keycloak_args} && touch ${_add_user_keycloak_state}",
+    creates     => $_add_user_keycloak_state,
+    environment => ['JAVA_OPTS=--add-modules java.se'],
+    notify      => Class['keycloak::service'],
   }
 
   file { "${keycloak::install_base}/standalone/configuration":


### PR DESCRIPTION
We've encountered this problem on several Keycloak versions (4.8.3 and up). It seems that this is a [known bug](https://issues.jboss.org/browse/KEYCLOAK-9923). [A fix](https://github.com/keycloak/keycloak/pull/5978) has been merged but it won't help with older Keycloak versions.

This PR adds the documented workaround to the Keycloak admin user creation Exec.