### PR TITLE
Add support for access.token.lifespan client attribute

### DIFF
--- a/lib/puppet/provider/keycloak_client/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client/kcadm.rb
@@ -8,7 +8,22 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
   def attributes_properties
     [
       :login_theme,
+      :access_token_lifespan,
     ]
+  end
+
+  def dot_attributes_properties
+    [
+      :access_token_lifespan,
+    ]
+  end
+
+  def attribute_key(property)
+    if dot_attributes_properties.include?(property)
+      property.to_s.tr('_', '.')
+    else
+      property
+    end
   end
 
   def self.instances
@@ -114,7 +129,7 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
         unless data.key?(:attributes)
           data[:attributes] = {}
         end
-        data[:attributes][property] = value
+        data[:attributes][attribute_key(property)] = value
       else
         data[camelize(property)] = value
       end
@@ -222,7 +237,7 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
           unless data.key?(:attributes)
             data[:attributes] = {}
           end
-          data[:attributes][property] = value
+          data[:attributes][attribute_key(property)] = value
         else
           data[camelize(property)] = value
         end

--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -143,6 +143,10 @@ Manage Keycloak clients
     defaultto 'absent'
   end
 
+  newproperty(:access_token_lifespan) do
+    desc 'access.token.lifespan'
+  end
+
   autorequire(:keycloak_client_scope) do
     requires = []
     catalog.resources.each do |resource|


### PR DESCRIPTION
This also fixes handling of attributes that have dots in their names, which
means most of them, excluding "login_theme". Here is a truncated example:

```
  "attributes" : {
    "saml.assertion.signature" : "false",
    "access.token.lifespan" : "600",
    "saml.multivalued.roles" : "false",
    "saml.force.post.binding" : "false",
    "saml.encrypt" : "false",
    "login_theme" : "keycloak",
    "saml.server.signature" : "false",
    "saml.server.signature.keyinfo.ext" : "false",
     --- snip ---
```
Without the dot_key fix in the "flush" method Puppet added and tried to manage _access_token_lifespan_ instead of _access.token.lifespan_.