### PR TITLE
Support oidc-group-membership-mapper protocol mapper type

### DIFF
--- a/lib/puppet/provider/keycloak_client_protocol_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client_protocol_mapper/kcadm.rb
@@ -42,9 +42,12 @@ Puppet::Type.type(:keycloak_client_protocol_mapper).provide(:kcadm, parent: Pupp
           if protocol_mapper[:type] == 'oidc-usermodel-property-mapper' || protocol_mapper[:type] == 'saml-user-property-mapper'
             protocol_mapper[:user_attribute] = d['config']['user.attribute']
           end
-          if protocol_mapper[:type] == 'oidc-usermodel-property-mapper'
+          if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(protocol_mapper[:type])
             protocol_mapper[:claim_name] = d['config']['claim.name']
             protocol_mapper[:json_type_label] = d['config']['jsonType.label']
+          end
+          if protocol_mapper[:type] == 'oidc-group-membership-mapper'
+            protocol_mapper[:full_path] = d['config']['full.path']
           end
           if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(protocol_mapper[:type])
             protocol_mapper[:friendly_name] = d['config']['friendly.name']
@@ -97,9 +100,12 @@ Puppet::Type.type(:keycloak_client_protocol_mapper).provide(:kcadm, parent: Pupp
     if resource[:type] == 'oidc-usermodel-property-mapper' || resource[:type] == 'saml-user-property-mapper'
       data[:config][:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
     end
-    if resource[:type] == 'oidc-usermodel-property-mapper'
+    if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(resource[:type])
       data[:config][:'claim.name'] = resource[:claim_name] if resource[:claim_name]
       data[:config][:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
+    end
+    if resource[:type] == 'oidc-group-membership-mapper'
+      data[:config][:'full.path'] = resource[:full_path] if resource[:full_path]
     end
     if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(resource[:type])
       data[:config][:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]
@@ -173,9 +179,12 @@ Puppet::Type.type(:keycloak_client_protocol_mapper).provide(:kcadm, parent: Pupp
       if resource[:type] == 'oidc-usermodel-property-mapper' || resource[:type] == 'saml-user-property-mapper'
         config[:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
       end
-      if resource[:type] == 'oidc-usermodel-property-mapper'
+      if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(resource[:type])
         config[:'claim.name'] = resource[:claim_name] if resource[:claim_name]
         config[:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
+      end
+      if resource[:type] == 'oidc-group-membership-mapper'
+        config[:'full.path'] = resource[:full_path] if resource[:full_path]
       end
       if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(resource[:type])
         config[:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]

--- a/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
+++ b/lib/puppet/provider/keycloak_protocol_mapper/kcadm.rb
@@ -42,9 +42,12 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, parent: Puppet::Pro
           if protocol_mapper[:type] == 'oidc-usermodel-property-mapper' || protocol_mapper[:type] == 'saml-user-property-mapper'
             protocol_mapper[:user_attribute] = d['config']['user.attribute']
           end
-          if protocol_mapper[:type] == 'oidc-usermodel-property-mapper'
+          if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(protocol_mapper[:type])
             protocol_mapper[:claim_name] = d['config']['claim.name']
             protocol_mapper[:json_type_label] = d['config']['jsonType.label']
+          end
+          if protocol_mapper[:type] == 'oidc-group-membership-mapper'
+            protocol_mapper[:full_path] = d['config']['full.path']
           end
           if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(protocol_mapper[:type])
             protocol_mapper[:friendly_name] = d['config']['friendly.name']
@@ -97,9 +100,12 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, parent: Puppet::Pro
     if resource[:type] == 'oidc-usermodel-property-mapper' || resource[:type] == 'saml-user-property-mapper'
       data[:config][:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
     end
-    if resource[:type] == 'oidc-usermodel-property-mapper'
+    if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(resource[:type])
       data[:config][:'claim.name'] = resource[:claim_name] if resource[:claim_name]
       data[:config][:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
+    end
+    if resource[:type] == 'oidc-group-membership-mapper'
+      data[:config][:'full.path'] = resource[:full_path] if resource[:full_path]
     end
     if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(resource[:type])
       data[:config][:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]
@@ -173,9 +179,12 @@ Puppet::Type.type(:keycloak_protocol_mapper).provide(:kcadm, parent: Puppet::Pro
       if resource[:type] == 'oidc-usermodel-property-mapper' || resource[:type] == 'saml-user-property-mapper'
         config[:'user.attribute'] = resource[:user_attribute] if resource[:user_attribute]
       end
-      if resource[:type] == 'oidc-usermodel-property-mapper'
+      if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(resource[:type])
         config[:'claim.name'] = resource[:claim_name] if resource[:claim_name]
         config[:'jsonType.label'] = resource[:json_type_label] if resource[:json_type_label]
+      end
+      if resource[:type] == 'oidc-group-membership-mapper'
+        config[:'full.path'] = resource[:full_path] if resource[:full_path]
       end
       if ['saml-user-property-mapper', 'saml-javascript-mapper'].include?(resource[:type])
         config[:'friendly.name'] = resource[:friendly_name] if resource[:friendly_name]

--- a/lib/puppet/type/keycloak_client_protocol_mapper.rb
+++ b/lib/puppet/type/keycloak_client_protocol_mapper.rb
@@ -57,6 +57,7 @@ Manage Keycloak protocol mappers
     newvalues(
       'oidc-usermodel-property-mapper',
       'oidc-full-name-mapper',
+      'oidc-group-membership-mapper',
       'saml-user-property-mapper',
       'saml-role-list-mapper',
       'saml-javascript-mapper',
@@ -85,10 +86,22 @@ Manage Keycloak protocol mappers
   end
 
   newproperty(:json_type_label) do
-    desc 'json.type.label. Default to `String` for `type` `oidc-usermodel-property-mapper`.'
+    desc 'json.type.label. Default to `String` for `type` `oidc-usermodel-property-mapper` and `oidc-group-membership-mapper`.'
     defaultto do
-      if @resource[:type] == 'oidc-usermodel-property-mapper'
+      if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(@resource[:type])
         'String'
+      else
+        nil
+      end
+    end
+  end
+
+  newproperty(:full_path, boolean: true) do
+    desc 'full.path. Default to `false` for `type` `oidc-group-membership-mapper`.'
+    newvalues(:true, :false)
+    defaultto do
+      if @resource[:type] == 'oidc-group-membership-mapper'
+        :false
       else
         nil
       end
@@ -221,7 +234,7 @@ Manage Keycloak protocol mappers
   end
 
   validate do
-    if self[:protocol] == 'openid-connect' && !['oidc-usermodel-property-mapper', 'oidc-full-name-mapper'].include?(self[:type])
+    if self[:protocol] == 'openid-connect' && !['oidc-usermodel-property-mapper', 'oidc-full-name-mapper', 'oidc-group-membership-mapper'].include?(self[:type])
       raise Puppet::Error, "type #{self[:type]} is not valid for protocol openid-connect"
     end
     if self[:protocol] == 'saml' && !['saml-user-property-mapper', 'saml-role-list-mapper', 'saml-javascript-mapper'].include?(self[:type])

--- a/lib/puppet/type/keycloak_protocol_mapper.rb
+++ b/lib/puppet/type/keycloak_protocol_mapper.rb
@@ -57,6 +57,7 @@ Manage Keycloak client scope protocol mappers
     newvalues(
       'oidc-usermodel-property-mapper',
       'oidc-full-name-mapper',
+      'oidc-group-membership-mapper',
       'saml-user-property-mapper',
       'saml-role-list-mapper',
       'saml-javascript-mapper',
@@ -85,10 +86,22 @@ Manage Keycloak client scope protocol mappers
   end
 
   newproperty(:json_type_label) do
-    desc 'json.type.label. Default to `String` for `type` `oidc-usermodel-property-mapper`.'
+    desc 'json.type.label. Default to `String` for `type` `oidc-usermodel-property-mapper` and `oidc-group-membership-mapper`.'
     defaultto do
-      if @resource[:type] == 'oidc-usermodel-property-mapper'
+      if ['oidc-usermodel-property-mapper', 'oidc-group-membership-mapper'].include?(@resource[:type])
         'String'
+      else
+        nil
+      end
+    end
+  end
+
+  newproperty(:full_path, boolean: true) do
+    desc 'full.path. Default to `false` for `type` `oidc-group-membership-mapper`.'
+    newvalues(:true, :false)
+    defaultto do
+      if @resource[:type] == 'oidc-group-membership-mapper'
+        :false
       else
         nil
       end
@@ -221,7 +234,7 @@ Manage Keycloak client scope protocol mappers
   end
 
   validate do
-    if self[:protocol] == 'openid-connect' && !['oidc-usermodel-property-mapper', 'oidc-full-name-mapper'].include?(self[:type])
+    if self[:protocol] == 'openid-connect' && !['oidc-usermodel-property-mapper', 'oidc-full-name-mapper', 'oidc-group-membership-mapper'].include?(self[:type])
       raise Puppet::Error, "type #{self[:type]} is not valid for protocol openid-connect"
     end
     if self[:protocol] == 'saml' && !['saml-user-property-mapper', 'saml-role-list-mapper', 'saml-javascript-mapper'].include?(self[:type])

--- a/spec/acceptance/7_client_protocol_mapper_spec.rb
+++ b/spec/acceptance/7_client_protocol_mapper_spec.rb
@@ -22,6 +22,10 @@ describe 'keycloak_client_protocol_mapper type:', if: RSpec.configuration.keyclo
         type                 => 'oidc-full-name-mapper',
         userinfo_token_claim => false,
       }
+      keycloak_client_protocol_mapper { "groups for test.foo.bar on test":
+        type       => 'oidc-group-membership-mapper',
+        claim_name => 'groups',
+      }
       EOS
 
       apply_manifest(pp, catch_failures: true)
@@ -44,6 +48,19 @@ describe 'keycloak_client_protocol_mapper type:', if: RSpec.configuration.keyclo
         mapper = data.select { |d| d['name'] == 'full name' }[0]
         expect(mapper['protocolMapper']).to eq('oidc-full-name-mapper')
         expect(mapper['config']['userinfo.token.claim']).to eq('false')
+      end
+    end
+
+    it 'has created protocol mapper groups' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get clients/test.foo.bar/protocol-mappers/models -r test' do
+        data = JSON.parse(stdout)
+        mapper = data.select { |d| d['name'] == 'groups' }[0]
+        expect(mapper['protocolMapper']).to eq('oidc-group-membership-mapper')
+        expect(mapper['config']['full.path']).to eq('false')
+        expect(mapper['config']['id.token.claim']).to eq('true')
+        expect(mapper['config']['access.token.claim']).to eq('true')
+        expect(mapper['config']['userinfo.token.claim']).to eq('true')
+        expect(mapper['config']['claim.name']).to eq('groups')
       end
     end
   end
@@ -70,6 +87,11 @@ describe 'keycloak_client_protocol_mapper type:', if: RSpec.configuration.keyclo
         type                 => 'oidc-full-name-mapper',
         userinfo_token_claim => true,
       }
+      keycloak_client_protocol_mapper { "groups for test.foo.bar on test":
+        type       => 'oidc-group-membership-mapper',
+        claim_name => 'groups',
+        full_path  => true,
+      }
       EOS
 
       apply_manifest(pp, catch_failures: true)
@@ -92,6 +114,19 @@ describe 'keycloak_client_protocol_mapper type:', if: RSpec.configuration.keyclo
         mapper = data.select { |d| d['name'] == 'full name' }[0]
         expect(mapper['protocolMapper']).to eq('oidc-full-name-mapper')
         expect(mapper['config']['userinfo.token.claim']).to eq('true')
+      end
+    end
+
+    it 'has updated protocol mapper groups' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get clients/test.foo.bar/protocol-mappers/models -r test' do
+        data = JSON.parse(stdout)
+        mapper = data.select { |d| d['name'] == 'groups' }[0]
+        expect(mapper['protocolMapper']).to eq('oidc-group-membership-mapper')
+        expect(mapper['config']['full.path']).to eq('true')
+        expect(mapper['config']['id.token.claim']).to eq('true')
+        expect(mapper['config']['access.token.claim']).to eq('true')
+        expect(mapper['config']['userinfo.token.claim']).to eq('true')
+        expect(mapper['config']['claim.name']).to eq('groups')
       end
     end
   end

--- a/spec/unit/puppet/type/keycloak_client_protocol_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_protocol_mapper_spec.rb
@@ -267,6 +267,16 @@ describe Puppet::Type.type(:keycloak_client_protocol_mapper) do
     end
   end
 
+  describe 'full_path' do
+    it 'defaults to nil for non groups' do
+      expect(resource[:full_path]).to be_nil
+    end
+    it 'defaults to false for groups' do
+      config[:type] = 'oidc-group-membership-mapper'
+      expect(resource[:full_path]).to eq(:false)
+    end
+  end
+
   it 'accepts Basic for attribute_nameformat' do
     config[:protocol] = 'saml'
     config[:attribute_nameformat] = 'Basic'

--- a/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
+++ b/spec/unit/puppet/type/keycloak_protocol_mapper_spec.rb
@@ -267,6 +267,16 @@ describe Puppet::Type.type(:keycloak_protocol_mapper) do
     end
   end
 
+  describe 'full_path' do
+    it 'defaults to nil for non groups' do
+      expect(resource[:full_path]).to be_nil
+    end
+    it 'defaults to false for groups' do
+      config[:type] = 'oidc-group-membership-mapper'
+      expect(resource[:full_path]).to eq(:false)
+    end
+  end
+
   it 'accepts Basic for attribute_nameformat' do
     config[:protocol] = 'saml'
     config[:attribute_nameformat] = 'Basic'


### PR DESCRIPTION
Allow keycloak_protocol_mapper and keycloak_client_protocol_mapper to have 'oidc-group-membership-mapper' for 'type'
Add full_path property to keycloak_protocol_mapper and keycloak_client_protocol_mapper