### PR TITLE
type/keycloak_api: Set install_dir default on /opt/keycloak

### DIFF
--- a/lib/puppet/type/keycloak_api.rb
+++ b/lib/puppet/type/keycloak_api.rb
@@ -22,6 +22,7 @@ Puppet::Type.newtype(:keycloak_api) do
 
   newparam(:install_dir) do
     desc 'Install location of Keycloak'
+    defaultto('/opt/keycloak')
   end
 
   newparam(:server) do


### PR DESCRIPTION
This PR sets a default value for the `install_dir` in the `keycloak_api` type. 

When this default is not set, and there is no `install_dir` given like
```puppet
  keycloak_api { 'keycloak':
    install_dir => '/opt/keycloak',
    realm       => 'master',
    user        => $master_realm_user,
    password    => $master_realm_password
  }
```
a Puppet run fails with `Failed to apply catalog: no implicit conversion of nil into String`

Just setting the `install_dir` makes the error go away, but I think it makes sense to set a default, as this is the general default installation directory for keycloak.