### PR TITLE
Remove outdated line in class documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,6 @@
 #   Default is `changeme`.
 # @param manage_datasource
 #   Boolean that determines if configured datasource will be managed.
-#   Only applies when `datasource_driver` is `mysql`.
 #   Default is `true`.
 # @param datasource_driver
 #   Datasource driver to use for Keycloak.


### PR DESCRIPTION
manage_datasource supports postgresql since https://github.com/treydock/puppet-module-keycloak/commit/02803c314a1da4a4a15eba1fe1c4d6a1f781389f