### PR TITLE
Update usage of deprecated function postgresql_password

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,7 @@ fixtures:
       ref: v10.2.0
     postgresql:
       repo: https://github.com/puppetlabs/puppetlabs-postgresql.git
-      ref: v6.2.0
+      ref: v6.4.0
     java:
       repo: https://github.com/puppetlabs/puppetlabs-java.git
       ref: v5.0.0

--- a/manifests/datasource/postgresql.pp
+++ b/manifests/datasource/postgresql.pp
@@ -44,7 +44,7 @@ class keycloak::datasource::postgresql {
     include ::postgresql::server
     postgresql::server::db { $keycloak::datasource_dbname:
       user     => $keycloak::datasource_username,
-      password => postgresql_password($keycloak::datasource_username, $keycloak::datasource_password),
+      password => postgresql::postgresql_password($keycloak::datasource_username, $keycloak::datasource_password),
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.2.0 <7.0.0"
+      "version_requirement": ">= 6.4.0 <7.0.0"
     },
     {
       "name": "puppetlabs/java",


### PR DESCRIPTION
The function `postgresql_password` was recently deprecated in puppetlabs-postgresql: https://github.com/puppetlabs/puppetlabs-postgresql/blob/master/REFERENCE.md#postgresql_password, causing a deprecation warning.

Suggested replacement: `postgresql::postgresql_password`