### PR TITLE
Explicitly specifies what user to use with the admin generation script

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,6 +28,7 @@ class keycloak::config {
     command => "${_add_user_keycloak_cmd} ${_add_user_keycloak_args} && touch ${_add_user_keycloak_state}",
     creates => $_add_user_keycloak_state,
     notify  => Class['keycloak::service'],
+    user    => $keycloak::user,
   }
 
   file { "${keycloak::install_base}/tmp":


### PR DESCRIPTION
**Description**
This change explicitly specifies what user to use with the admin generation script,
so the keycloak would have no issues accessing generated keycloak-add-user.json.

**Background**
The add-user-keycloak generates keycloak-add-user.json belonging to a user that runs the script.
This means if puppet and keycloak services belong to different users,
without this change there was no guarantee that keycloak could access to this file after creation.