### PR TITLE
Add registration_allowed to keycloak_realm

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2641,6 +2641,14 @@ rememberMe
 
 Default value: false
 
+##### `registration_allowed`
+
+Valid values: `true`, `false`
+
+registrationAllowed
+
+Default value: false
+
 ##### `login_with_email_allowed`
 
 Valid values: `true`, `false`

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -100,6 +100,12 @@ Manage Keycloak realms
     defaultto :false
   end
 
+  newproperty(:registration_allowed, boolean: true) do
+    desc 'registrationAllowed'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
   newproperty(:login_with_email_allowed, boolean: true) do
     desc 'loginWithEmailAllowed'
     newvalues(:true, :false)

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -34,6 +34,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         data = JSON.parse(stdout)
         expect(data['id']).to eq('test')
         expect(data['bruteForceProtected']).to eq(false)
+        expect(data['registrationAllowed']).to eq(false)
       end
     end
 
@@ -95,6 +96,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
       keycloak_realm { 'test':
         ensure => 'present',
         remember_me => true,
+        registration_allowed => true,
         access_code_lifespan => 3600,
         access_token_lifespan => 3600,
         sso_session_idle_timeout => 3600,
@@ -128,6 +130,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
       on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get realms/test' do
         data = JSON.parse(stdout)
         expect(data['rememberMe']).to eq(true)
+        expect(data['registrationAllowed']).to eq(true)
         expect(data['accessCodeLifespan']).to eq(3600)
         expect(data['accessTokenLifespan']).to eq(3600)
         expect(data['ssoSessionIdleTimeout']).to eq(3600)

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -114,6 +114,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     # Test boolean properties
     [
       :remember_me,
+      :registration_allowed,
       :login_with_email_allowed,
       :internationalization_enabled,
       :events_enabled,


### PR DESCRIPTION
Enable to set  `registrationAllowed` realm parameter value from puppet.