### PR TITLE
Add more realm login related properties

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2669,6 +2669,14 @@ loginWithEmailAllowed
 
 Default value: true
 
+##### `reset_password_allowed`
+
+Valid values: `true`, `false`
+
+resetPasswordAllowed
+
+Default value: false
+
 ##### `browser_flow`
 
 browserFlow

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2677,6 +2677,14 @@ resetPasswordAllowed
 
 Default value: false
 
+##### `verify_email`
+
+Valid values: `true`, `false`
+
+verifyEmail
+
+Default value: false
+
 ##### `browser_flow`
 
 browserFlow

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -112,6 +112,12 @@ Manage Keycloak realms
     defaultto :true
   end
 
+  newproperty(:reset_password_allowed, boolean: true) do
+    desc 'resetPasswordAllowed'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
   newproperty(:browser_flow) do
     desc 'browserFlow'
     defaultto('browser')

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -118,6 +118,12 @@ Manage Keycloak realms
     defaultto :false
   end
 
+  newproperty(:verify_email, boolean: true) do
+    desc 'verifyEmail'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
   newproperty(:browser_flow) do
     desc 'browserFlow'
     defaultto('browser')

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -36,6 +36,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['bruteForceProtected']).to eq(false)
         expect(data['registrationAllowed']).to eq(false)
         expect(data['resetPasswordAllowed']).to eq(false)
+        expect(data['verifyEmail']).to eq(false)
       end
     end
 
@@ -99,6 +100,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         remember_me => true,
         registration_allowed => true,
         reset_password_allowed => true,
+        verify_email => true,
         access_code_lifespan => 3600,
         access_token_lifespan => 3600,
         sso_session_idle_timeout => 3600,
@@ -134,6 +136,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['rememberMe']).to eq(true)
         expect(data['registrationAllowed']).to eq(true)
         expect(data['resetPasswordAllowed']).to eq(true)
+        expect(data['verifyEmail']).to eq(true)
         expect(data['accessCodeLifespan']).to eq(3600)
         expect(data['accessTokenLifespan']).to eq(3600)
         expect(data['ssoSessionIdleTimeout']).to eq(3600)

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -35,6 +35,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['id']).to eq('test')
         expect(data['bruteForceProtected']).to eq(false)
         expect(data['registrationAllowed']).to eq(false)
+        expect(data['resetPasswordAllowed']).to eq(false)
       end
     end
 
@@ -97,6 +98,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         ensure => 'present',
         remember_me => true,
         registration_allowed => true,
+        reset_password_allowed => true,
         access_code_lifespan => 3600,
         access_token_lifespan => 3600,
         sso_session_idle_timeout => 3600,
@@ -131,6 +133,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         data = JSON.parse(stdout)
         expect(data['rememberMe']).to eq(true)
         expect(data['registrationAllowed']).to eq(true)
+        expect(data['resetPasswordAllowed']).to eq(true)
         expect(data['accessCodeLifespan']).to eq(3600)
         expect(data['accessTokenLifespan']).to eq(3600)
         expect(data['ssoSessionIdleTimeout']).to eq(3600)

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -116,6 +116,7 @@ describe Puppet::Type.type(:keycloak_realm) do
       :remember_me,
       :registration_allowed,
       :reset_password_allowed,
+      :verify_email,
       :login_with_email_allowed,
       :internationalization_enabled,
       :events_enabled,

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -115,6 +115,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     [
       :remember_me,
       :registration_allowed,
+      :reset_password_allowed,
       :login_with_email_allowed,
       :internationalization_enabled,
       :events_enabled,


### PR DESCRIPTION
That PR enables to set `resetPasswordAllowed` and `verifyEmail` options to a realm from Puppet.