### PR TITLE
Enable roles management at realm and client level

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1254,6 +1254,12 @@ authenticationFlowBindingOverrides.direct_grant (Use flow alias, not ID)
 
 Default value: absent
 
+##### `roles`
+
+List of non composite client roles to define.
+
+Default value: []
+
 #### Parameters
 
 The following parameters are available in the `keycloak_client` type.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2833,6 +2833,12 @@ Valid values: `true`, `false`
 
 bruteForceProtected
 
+##### `roles`
+
+List of non composite realm roles to define.
+
+Default value: ['offline_access', 'uma_authorization']
+
 #### Parameters
 
 The following parameters are available in the `keycloak_realm` type.

--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -185,6 +185,11 @@ Manage Keycloak clients
     defaultto :absent
   end
 
+  newproperty(:roles, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
+    desc 'roles'
+    defaultto []
+  end
+
   autorequire(:keycloak_client_scope) do
     requires = []
     catalog.resources.each do |resource|

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -273,4 +273,9 @@ Manage Keycloak realms
     desc 'bruteForceProtected'
     newvalues(:true, :false)
   end
+
+  newproperty(:roles, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
+    desc 'roles'
+    defaultto ['offline_access', 'uma_authorization']
+  end
 end

--- a/spec/unit/puppet/provider/keycloak_client/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_client/kcadm_spec.rb
@@ -18,6 +18,14 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
       allow(described_class).to receive(:kcadm).with('get', 'clients/example.com/client-secret', 'test').and_return(my_fixture_read('get-client-secret.out'))
       allow(described_class).to receive(:kcadm).with('get', 'authentication/flows', 'master', nil, ['id', 'alias']).and_return('[]')
       allow(described_class).to receive(:kcadm).with('get', 'authentication/flows', 'test', nil, ['id', 'alias']).and_return(my_fixture_read('get-flows.out'))
+      master_clients = JSON.parse(my_fixture_read('get-master.out'))
+      test_clients = JSON.parse(my_fixture_read('get-test.out'))
+      master_clients.each do |c|
+        allow(described_class).to receive(:get_client_roles).with('master', c['id']).and_return([])
+      end
+      test_clients.each do |c|
+        allow(described_class).to receive(:get_client_roles).with('test', c['id']).and_return([])
+      end
       expect(described_class.instances.length).to eq(7 + 6)
     end
 
@@ -28,9 +36,18 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
       allow(described_class).to receive(:kcadm).with('get', 'clients/example.com/client-secret', 'test').and_return(my_fixture_read('get-client-secret.out'))
       allow(described_class).to receive(:kcadm).with('get', 'authentication/flows', 'master', nil, ['id', 'alias']).and_return('[]')
       allow(described_class).to receive(:kcadm).with('get', 'authentication/flows', 'test', nil, ['id', 'alias']).and_return(my_fixture_read('get-flows.out'))
+      master_clients = JSON.parse(my_fixture_read('get-master.out'))
+      test_clients = JSON.parse(my_fixture_read('get-test.out'))
+      master_clients.each do |c|
+        allow(described_class).to receive(:get_client_roles).with('master', c['id']).and_return([])
+      end
+      test_clients.each do |c|
+        allow(described_class).to receive(:get_client_roles).with('test', c['id']).and_return([])
+      end
       property_hash = described_class.instances[0].instance_variable_get('@property_hash')
       expect(property_hash[:name]).to eq('example.com on test')
       expect(property_hash[:browser_flow]).to eq('browser')
+      expect(property_hash[:roles]).to eq([])
     end
   end
   #   describe 'self.prefetch' do
@@ -55,11 +72,14 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
   #     end
   #   end
   describe 'create' do
-    it 'creates a realm' do
+    it 'creates a client' do
       resource[:browser_flow] = 'browser'
+      resource[:roles] = ['foo_role']
       temp = Tempfile.new('keycloak_client')
+      rtemp = Tempfile.new('keycloak_client_role')
       allow(Tempfile).to receive(:new).with('keycloak_client').and_return(temp)
       allow(resource.provider).to receive(:kcadm).with('get', 'client-scopes', 'test', nil, ['id', 'name']).and_return(my_fixture_read('get-scopes.out'))
+      allow(described_class).to receive(:get_client_roles).with('test', 'foo').and_return([])
       expect(resource.provider).to receive(:kcadm).with('create', 'clients', 'test', temp.path).and_return(my_fixture_read('get-client.out'))
       expect(resource.provider).to receive(:kcadm).with('delete', 'clients/foo/default-client-scopes/b8ebafcc-485f-44d2-9fe6-f4ed0da80980', 'test')
       expect(resource.provider).to receive(:kcadm).with('delete', 'clients/foo/default-client-scopes/3e40378d-d26d-471f-b2c7-7a3d9651e588', 'test')
@@ -68,6 +88,8 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
       expect(resource.provider).to receive(:kcadm).with('delete', 'clients/foo/optional-client-scopes/dbd3b1c1-9159-46d9-a879-9602972f1994', 'test')
       expect(resource.provider).to receive(:kcadm).with('update', 'clients/foo/default-client-scopes/ee85ec64-4853-4fd4-a2f4-ff578016c9b5', 'test')
       allow(described_class).to receive(:kcadm).with('get', 'authentication/flows', 'test', nil, ['id', 'alias']).and_return(my_fixture_read('get-flows.out'))
+      allow(Tempfile).to receive(:new).with('keycloak_client_role').and_return(rtemp)
+      expect(resource.provider).to receive(:kcadm).with('create', 'clients/foo/roles', 'test', rtemp.path)
       resource.provider.create
       property_hash = resource.provider.instance_variable_get('@property_hash')
       expect(property_hash[:ensure]).to eq(:present)
@@ -78,7 +100,7 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
   end
 
   describe 'destroy' do
-    it 'deletes a realm' do
+    it 'deletes a client' do
       hash = resource.to_hash
       resource.provider.instance_variable_set(:@property_hash, hash)
       expect(resource.provider).to receive(:kcadm).with('delete', 'clients/foo', 'test')
@@ -89,13 +111,21 @@ describe Puppet::Type.type(:keycloak_client).provider(:kcadm) do
   end
 
   describe 'flush' do
-    it 'updates a realm' do
+    it 'updates a client' do
       hash = resource.to_hash
       resource.provider.instance_variable_set(:@property_hash, hash)
       temp = Tempfile.new('keycloak_client')
+      rtemp = Tempfile.new('keycloak_client_role')
       allow(Tempfile).to receive(:new).with('keycloak_client').and_return(temp)
+      allow(Tempfile).to receive(:new).with('keycloak_client_role').and_return(rtemp)
+      allow(described_class).to receive(:get_client_roles).with('test', 'foo').and_return(['foo_role'])
       expect(resource.provider).to receive(:kcadm).with('update', 'clients/foo', 'test', temp.path)
+      expect(resource.provider).to receive(:kcadm).with('delete', 'clients/foo/roles/foo_role', 'test')
+      expect(resource.provider).to receive(:kcadm).with('create', 'clients/foo/roles', 'test', rtemp.path)
+      property_hash = resource.provider.instance_variable_get('@property_hash')
+      property_hash[:roles] = ['foo_role']
       resource.provider.redirect_uris = ['foobar']
+      resource.provider.roles = ['new_foo_role']
       resource.provider.flush
     end
 

--- a/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_realm/kcadm_spec.rb
@@ -17,6 +17,8 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
       allow(described_class).to receive(:get_client_scopes).with('master', 'optional').and_return('address' => '1cda5a52-aa2c-4b07-b620-30b703619581')
       allow(described_class).to receive(:get_events_config).with('test').and_return({})
       allow(described_class).to receive(:get_events_config).with('master').and_return({})
+      allow(described_class).to receive(:get_realm_roles).with('test').and_return(['offline_access', 'uma_authorization'])
+      allow(described_class).to receive(:get_realm_roles).with('master').and_return(['offline_access', 'uma_authorization'])
       expect(described_class.instances.length).to eq(2)
     end
 
@@ -28,11 +30,14 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
       allow(described_class).to receive(:get_client_scopes).with('master', 'optional').and_return('address' => '1cda5a52-aa2c-4b07-b620-30b703619581')
       allow(described_class).to receive(:get_events_config).with('test').and_return({})
       allow(described_class).to receive(:get_events_config).with('master').and_return({})
+      allow(described_class).to receive(:get_realm_roles).with('test').and_return(['offline_access', 'uma_authorization'])
+      allow(described_class).to receive(:get_realm_roles).with('master').and_return(['offline_access', 'uma_authorization'])
       property_hash = described_class.instances[0].instance_variable_get('@property_hash')
       expect(property_hash[:enabled]).to eq(:true)
       expect(property_hash[:login_with_email_allowed]).to eq(:false)
       expect(property_hash[:default_client_scopes]).to eq(['profile'])
       expect(property_hash[:optional_client_scopes]).to eq(['address'])
+      expect(property_hash[:roles]).to eq(['offline_access', 'uma_authorization'])
     end
   end
   #   describe 'self.prefetch' do
@@ -60,10 +65,15 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
     it 'creates a realm' do
       temp = Tempfile.new('keycloak_realm')
       etemp = Tempfile.new('keycloak_events_config')
+      rtemp = Tempfile.new('keycloak_realm_role')
       allow(Tempfile).to receive(:new).with('keycloak_realm').and_return(temp)
       allow(Tempfile).to receive(:new).with('keycloak_events_config').and_return(etemp)
+      allow(Tempfile).to receive(:new).with('keycloak_realm_role').and_return(rtemp)
+      allow(described_class).to receive(:get_realm_roles).with('test').and_return(['offline_access', 'uma_authorization'])
       expect(resource.provider).to receive(:kcadm).with('create', 'realms', nil, temp.path)
+      expect(resource.provider).to receive(:kcadm).with('create', 'roles', 'test', rtemp.path)
       expect(resource.provider).to receive(:kcadm).with('update', 'events/config', 'test', etemp.path)
+      resource[:roles] = ['offline_access', 'uma_authorization', 'new_role']
       resource.provider.create
       property_hash = resource.provider.instance_variable_get('@property_hash')
       expect(property_hash[:ensure]).to eq(:present)
@@ -83,12 +93,19 @@ describe Puppet::Type.type(:keycloak_realm).provider(:kcadm) do
     it 'updates a realm' do
       temp = Tempfile.new('keycloak_realm')
       etemp = Tempfile.new('keycloak_events_config')
+      rtemp = Tempfile.new('keycloak_realm_role')
       allow(Tempfile).to receive(:new).with('keycloak_realm').and_return(temp)
       allow(Tempfile).to receive(:new).with('keycloak_events_config').and_return(etemp)
+      allow(Tempfile).to receive(:new).with('keycloak_realm_role').and_return(rtemp)
       allow(resource.provider).to receive(:kcadm).with('get', 'authentication/flows', 'test', nil, ['alias']).and_return('[]')
       expect(resource.provider).to receive(:kcadm).with('update', 'realms/test', nil, temp.path)
+      expect(resource.provider).to receive(:kcadm).with('delete', 'roles/offline_access', 'test')
+      expect(resource.provider).to receive(:kcadm).with('create', 'roles', 'test', rtemp.path)
       expect(resource.provider).to receive(:kcadm).with('update', 'events/config', 'test', etemp.path)
+      property_hash = resource.provider.instance_variable_get('@property_hash')
+      property_hash[:roles] = ['offline_access', 'uma_authorization']
       resource.provider.login_with_email_allowed = :false
+      resource.provider.roles = ['uma_authorization', 'new_role']
       resource.provider.flush
     end
   end

--- a/spec/unit/puppet/type/keycloak_client_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_spec.rb
@@ -144,6 +144,7 @@ describe Puppet::Type.type(:keycloak_client) do
       :optional_client_scopes,
       :redirect_uris,
       :web_origins,
+      :roles,
     ].each do |p|
       it "should accept array for #{p}" do
         config[p] = ['foo', 'bar']

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -163,6 +163,7 @@ describe Puppet::Type.type(:keycloak_realm) do
       :optional_client_scopes,
       :events_listeners,
       :supported_locales,
+      :roles,
     ].each do |p|
       it "should accept array for #{p}" do
         config[p] = ['foo', 'bar']


### PR DESCRIPTION
That PR enables to create/delete [roles](https://www.keycloak.org/docs/6.0/server_admin/#roles) at realm and client level.

Only simple (non composite) roles are considered.

Composite roles management could be added later by adding a new `keycloak_composite_role` type
setting the mapping between the new composite role and a list of other existing roles.
