### PR TITLE
Vagrant: install puppetlabs-concat during provisioning

### DIFF
--- a/vagrant-common.sh
+++ b/vagrant-common.sh
@@ -6,6 +6,7 @@ puppet module install puppetlabs-stdlib
 puppet module install puppetlabs-mysql
 puppet module install puppetlabs-java
 puppet module install puppetlabs-java_ks
+puppet module install puppetlabs-concat
 puppet module install puppet-archive
 puppet module install camptocamp-systemd
 ln -s /vagrant /etc/puppetlabs/code/environments/production/modules/keycloak


### PR DESCRIPTION
Without it provisioning fails with missing module error.