### PR TITLE
Add convenience define for setting up FreeIPA LDAP mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ keycloak_ldap_user_provider { 'LDAP on test':
 
 **NOTE** The `Id` for the above resource would be `LDAP-test` where the format is `${resource_name}-${realm}`.
 
-If you're using FreeIPA you use a defined resource that wraps keycloak\_ldap\_user\_provider:
+If you're using FreeIPA you can use a defined resource that wraps keycloak\_ldap\_user\_provider:
 
-```
+```puppet
 keycloak::freeipa_user_provider { 'ipa.example.org':
   ensure          => 'present',
   realm           => 'EXAMPLE.ORG',
@@ -278,6 +278,17 @@ keycloak_ldap_mapper { 'full name for LDAP-test on test:
   resource_name  => 'full name',
   type           => 'full-name-ldap-mapper',
   ldap_attribute => 'gecos',
+}
+```
+
+If you're using FreeIPA you can use a defined resource that adds all the
+required attribute mappings automatically:
+
+```puppet
+keycloak::freeipa_ldap_mappers { 'ipa.example.org':
+  realm            => 'EXAMPLE.ORG',
+  groups_dn        => 'cn=groups,cn=accounts,dc=example,dc=org',
+  roles_dn         => 'cn=groups,cn=accounts,dc=example,dc=org'
 }
 ```
 

--- a/manifests/freeipa_ldap_mappers.pp
+++ b/manifests/freeipa_ldap_mappers.pp
@@ -1,0 +1,120 @@
+#
+# @summary setup FreeIPA LDAP mappers for Keycloak
+#
+# @example
+#   keycloak::freeipa_ldap_mappers { 'ipa.example.org':
+#     ldap_provider_id => '6bd0f68d-5618-a74d-bcab-089702f1bc80',
+#     realm            => 'EXAMPLE.ORG',
+#     groups_dn        => 'cn=groups,cn=accounts,dc=example,dc=org',
+#     roles_dn         => 'cn=groups,cn=accounts,dc=example,dc=org'
+#   }
+#
+# @param parent_name
+#   The name of the parent resource. Usually the title of the
+#   keycloak_ldap_provider.
+# @param realm
+#   Keycloak realm
+# @param groups_dn
+#   Groups DN
+# @param roles_dn
+#   Roles DN
+# @param ldap_provider_id
+#   Identifier for the LDAP provider to add this mapper to
+#
+define keycloak::freeipa_ldap_mappers
+(
+  String $realm,
+  String $groups_dn,
+  String $roles_dn,
+  String $parent_name = $title,
+  String $ldap_provider_id = $title,
+)
+{
+  $title_suffix = "for ${ldap_provider_id} on ${realm}"
+
+  # This translates to parentId in JSON and must be correct or hard-to-debug
+  # issues will ensue.
+  $ldap = "${parent_name}-${realm}"
+
+  keycloak_ldap_mapper {
+    default:
+      ensure                      => 'present',
+      ldap                        => $ldap,
+      always_read_value_from_ldap => true,
+      read_only                   => true,
+      is_mandatory_in_ldap        => true,
+    ;
+    ["cn ${title_suffix}"]:
+      ldap_attribute       => 'cn',
+      user_model_attribute => 'cn',
+    ;
+    ["displayName ${title_suffix}"]:
+      ldap_attribute       => 'displayName',
+      user_model_attribute => 'displayName',
+    ;
+    ["email ${title_suffix}"]:
+      ldap_attribute       => 'mail',
+      user_model_attribute => 'email',
+    ;
+    ["first name ${title_suffix}"]:
+      ldap_attribute       => 'givenName',
+      user_model_attribute => 'firstName',
+    ;
+    ["last name ${title_suffix}"]:
+      ldap_attribute       => 'sn',
+      user_model_attribute => 'lastName',
+    ;
+    ["username ${title_suffix}"]:
+      ldap_attribute       => 'uid',
+      user_model_attribute => 'username',
+    ;
+    ["modify date ${title_suffix}"]:
+      is_mandatory_in_ldap => false,
+      ldap_attribute       => 'modifyTimestamp',
+      user_model_attribute => 'modifyTimestamp',
+    ;
+    ["creation date ${title_suffix}"]:
+      is_mandatory_in_ldap => false,
+      ldap_attribute       => 'createTimestamp',
+      user_model_attribute => 'createTimestamp',
+    ;
+  }
+
+  keycloak_ldap_mapper { "roles ${title_suffix}":
+    ensure                         => 'present',
+    type                           => 'role-ldap-mapper',
+    ldap                           => $ldap,
+    is_mandatory_in_ldap           => false,
+    mode                           => 'READ_ONLY',
+    memberof_ldap_attribute        => 'memberOf',
+    membership_attribute_type      => 'UID',
+    membership_ldap_attribute      => 'memberUid',
+    membership_user_ldap_attribute => 'uid',
+    read_only                      => true,
+    role_name_ldap_attribute       => 'cn',
+    role_object_classes            => 'posixGroup',
+    roles_dn                       => $roles_dn,
+    use_realm_roles_mapping        => true,
+    user_roles_retrieve_strategy   => 'LOAD_ROLES_BY_MEMBER_ATTRIBUTE',
+  }
+
+  keycloak_ldap_mapper { "groups ${title_suffix}":
+    ensure                               => 'present',
+    type                                 => 'group-ldap-mapper',
+    ldap                                 => $ldap,
+    is_mandatory_in_ldap                 => false,
+    mode                                 => 'READ_ONLY',
+    memberof_ldap_attribute              => 'memberOf',
+    drop_non_existing_groups_during_sync => true,
+    group_name_ldap_attribute            => 'cn',
+    group_object_classes                 => 'groupOfNames, posixGroup',
+    groups_dn                            => $groups_dn,
+    ignore_missing_groups                => false,
+    membership_attribute_type            => 'DN',
+    membership_ldap_attribute            => 'member',
+    membership_user_ldap_attribute       => 'uid',
+    preserve_group_inheritance           => false,
+    read_only                            => true,
+    user_roles_retrieve_strategy         => 'LOAD_GROUPS_BY_MEMBER_ATTRIBUTE',
+  }
+}

--- a/spec/acceptance/3_ldap_spec.rb
+++ b/spec/acceptance/3_ldap_spec.rb
@@ -305,4 +305,33 @@ describe 'keycloak_ldap_user_provider:', if: RSpec.configuration.keycloak_full d
       apply_manifest(pp, catch_changes: true)
     end
   end
+
+  context 'creates freeipa ldap mappers' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_realm { 'test': ensure => 'present' }
+      keycloak::freeipa_user_provider { 'ipa.example.org':
+        ensure => 'present',
+        realm => 'test',
+        bind_dn => 'uid=ldapproxy,cn=sysaccounts,cn=etc,dc=example,dc=org',
+        bind_credential => 'secret',
+        users_dn => 'cn=users,cn=accounts,dc=example,dc=org',
+        priority => 10,
+        ldaps => false,
+      }
+      keycloak::freeipa_ldap_mappers { 'ipa.example.org':
+        realm => 'test',
+        groups_dn => 'cn=groups,cn=accounts,dc=example,dc=org',
+        roles_dn => 'cn=groups,cn=accounts,dc=example,dc=org',
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
 end

--- a/spec/defines/freeipa_ldap_mappers_spec.rb
+++ b/spec/defines/freeipa_ldap_mappers_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe 'keycloak::freeipa_ldap_mappers' do
+  on_supported_os.each do |os, _facts|
+    context "on #{os}" do
+      let(:version) { '8.0.1' }
+      let(:title) { 'ipa.example.org' }
+      let(:params) do
+        {
+          realm: 'EXAMPLE.ORG',
+          groups_dn: 'cn=groups,cn=accounts,dc=example,dc=org',
+          roles_dn: 'cn=groups,cn=accounts,dc=example,dc=org',
+          parent_id: 'ipa.example.org',
+        }
+      end
+
+      it do
+        is_expected.to contain_keycloak_ldap_mapper('groups for ipa.example.org').with(
+          ensure: 'present',
+          realm: 'EXAMPLE.ORG',
+          type: 'group-ldap-mapper',
+          ldap: 'ipa.example.org',
+          is_mandatory_in_ldap: false,
+          mode: 'READ_ONLY',
+          memberof_ldap_attribute: 'memberOf',
+          drop_non_existing_groups_during_sync: true,
+          group_name_ldap_attribute: 'cn',
+          group_object_classes: 'groupOfNames, posixGroup',
+          groups_dn: 'cn=groups,cn=accounts,dc=example,dc=org',
+          ignore_missing_groups: false,
+          membership_attribute_type: 'DN',
+          membership_ldap_attribute: 'member',
+          membership_user_ldap_attribute: 'uid',
+          preserve_group_inheritance: false,
+          user_roles_retrieve_strategy: 'LOAD_GROUPS_BY_MEMBER_ATTRIBUTE',
+        )
+      end
+
+      it do
+        is_expected.to contain_keycloak_ldap_mapper('roles for ipa.example.org').with(
+          ensure: 'present',
+          realm: 'EXAMPLE.ORG',
+          type: 'role-ldap-mapper',
+          ldap:  'ipa.example.org',
+          is_mandatory_in_ldap: false,
+          mode: 'READ_ONLY',
+          memberof_ldap_attribute: 'memberOf',
+          membership_attribute_type: 'UID',
+          membership_ldap_attribute: 'memberUid',
+          membership_user_ldap_attribute: 'uid',
+          role_name_ldap_attribute: 'cn',
+          role_object_classes: 'posixGroup',
+          roles_dn: 'cn=groups,cn=accounts,dc=example,dc=org',
+          use_realm_roles_mapping: true,
+          user_roles_retrieve_strategy: 'LOAD_ROLES_BY_MEMBER_ATTRIBUTE',
+        )
+      end
+
+      it do
+        attrs = [['cn', 'cn', 'cn'],
+                 ['displayName', 'displayName', 'displayName'],
+                 ['email', 'mail', 'email'],
+                 ['first name', 'givenName', 'firstName'],
+                 ['last name', 'sn', 'lastName'],
+                 ['username', 'uid', 'username']]
+
+        attrs.each do |attr|
+          name = attr[0]
+          ldap_attribute = attr[1]
+          user_model_attribute = attr[2]
+
+          is_expected.to contain_keycloak_ldap_mapper("#{name} for ipa.example.org").with(
+            ensure: 'present',
+            realm: 'EXAMPLE.ORG',
+            ldap: 'ipa.example.org',
+            always_read_value_from_ldap: true,
+            read_only: true,
+            is_mandatory_in_ldap: true,
+            ldap_attribute: ldap_attribute,
+            user_model_attribute: user_model_attribute,
+          )
+        end
+      end
+
+      it do
+        is_expected.to contain_keycloak_ldap_mapper('modify date for ipa.example.org').with(
+          is_mandatory_in_ldap: false,
+          ldap_attribute: 'modifyTimestamp',
+          user_model_attribute: 'modifyTimestamp',
+        )
+      end
+
+      it do
+        is_expected.to contain_keycloak_ldap_mapper('creation date for ipa.example.org').with(
+          is_mandatory_in_ldap: false,
+          ldap_attribute: 'createTimestamp',
+          user_model_attribute: 'createTimestamp',
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The mappings are well-known, so there's no reason for all FreeIPA users to set
them up separately.