### PR TITLE
Fix missing IntegerProperty when keycloak_ldap_user_provider

### DIFF
--- a/lib/puppet/type/keycloak_ldap_user_provider.rb
+++ b/lib/puppet/type/keycloak_ldap_user_provider.rb
@@ -1,5 +1,6 @@
 require_relative '../../puppet_x/keycloak/type'
 require_relative '../../puppet_x/keycloak/array_property'
+require_relative '../../puppet_x/keycloak/integer_property'
 
 Puppet::Type.newtype(:keycloak_ldap_user_provider) do
   desc <<-DESC


### PR DESCRIPTION
The `IntegerProperty` is currently not explicitly required in the keycloak_ldap_user_provider which relies on that class. This does not cause issues most of the time as long as other classes that use `IntegerProperty` are loaded first. But under certain conditions like spec tests, the missing require causes failures like that:

```
error during compilation: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/keycloak_ldap_user_provider: uninitialized constant PuppetX::Keycloak::IntegerProperty
       Did you mean?  Interrupt (file: /.../provider/ldap.pp, line: 65, column: 5) on node laptop-esoynov.localdomain
     # ./../keycloak/provider/ldap_spec.rb:22:in `block (4 levels) in <top (required)>'
```

I've added the explicit `require_relative` as it's done in other classes to fix the issue.