### PR TITLE
FreeIPA/LDAP provider related regression fixes

### DIFF
--- a/lib/puppet/provider/keycloak_realm/kcadm.rb
+++ b/lib/puppet/provider/keycloak_realm/kcadm.rb
@@ -247,7 +247,7 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, parent: Puppet::Provider::Key
       end
     end
     role = nil
-    if resource[:roles]
+    if resource[:roles] && resource[:manage_roles].to_s == 'true'
       roles = get_realm_roles(resource[:name])
       remove_roles = roles - resource[:roles]
       begin
@@ -413,7 +413,7 @@ Puppet::Type.type(:keycloak_realm).provide(:kcadm, parent: Puppet::Provider::Key
         end
       end
       role = nil
-      if @property_flush[:roles]
+      if @property_flush[:roles] && resource[:manage_roles].to_s == 'true'
         remove_roles = @property_hash[:roles] - @property_flush[:roles]
         begin
           remove_roles.each do |s|

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -282,8 +282,21 @@ Manage Keycloak realms
     newvalues(:true, :false)
   end
 
+  newparam(:manage_roles, boolean: true) do
+    desc 'Manage realm roles'
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
   newproperty(:roles, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
     desc 'roles'
     defaultto ['offline_access', 'uma_authorization']
+
+    def insync?(is)
+      if resource[:manage_roles].to_s == 'false'
+        return true
+      end
+      super(is)
+    end
   end
 end

--- a/manifests/freeipa_user_provider.pp
+++ b/manifests/freeipa_user_provider.pp
@@ -27,6 +27,10 @@
 #   Priority for this user provider
 # @param ldaps
 #   Use LDAPS protocol instead of LDAP
+# @param full_sync_period
+#   Synchronize all users this often (fullSyncPeriod)
+# @param changed_sync_period
+#   Synchronize changed users this often (changedSyncPeriod)
 #
 define keycloak::freeipa_user_provider
 (
@@ -38,6 +42,8 @@ define keycloak::freeipa_user_provider
   Stdlib::Host              $ipa_host = $title,
   Integer                   $priority = 10,
   Boolean                   $ldaps = false,
+  Optional[Integer]         $full_sync_period = undef,
+  Optional[Integer]         $changed_sync_period = undef
 )
 {
   if $ldaps {
@@ -65,5 +71,7 @@ define keycloak::freeipa_user_provider
     users_dn                                 => $users_dn,
     uuid_ldap_attribute                      => 'ipaUniqueID',
     vendor                                   => 'rhds',
+    full_sync_period                         => $full_sync_period,
+    changed_sync_period                      => $changed_sync_period,
   }
 }

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -121,6 +121,7 @@ describe Puppet::Type.type(:keycloak_realm) do
       :verify_email,
       :login_with_email_allowed,
       :internationalization_enabled,
+      :manage_roles,
       :events_enabled,
       :admin_events_enabled,
       :admin_events_details_enabled,


### PR DESCRIPTION
This PR fixes a couple of issues encountered when testing the latest code against FreeIPA:
* The default value defined for realm roles made the keycloak_realm provider (want to) overwrite realm roles that came from FreeIPA (or any other LDAP server, for that matter). Workarounds like adding "roles => undef" or "roles => false" did not help. Simply removing the default value for "roles" the keycloak_realm type fixes this
* FreeIPA provider now supports full_sync_period and changed_sync_period parameter. Previously this was not necessary/possible as support for it was lacking from keycloak_ldap_user_provider.