### PR TITLE
Vagrant: install puppetlabs-postgresql

### DIFF
--- a/vagrant-common.sh
+++ b/vagrant-common.sh
@@ -4,6 +4,7 @@
 #
 puppet module install puppetlabs-stdlib
 puppet module install puppetlabs-mysql
+puppet module install puppetlabs-postgresql
 puppet module install puppetlabs-java
 puppet module install puppetlabs-java_ks
 puppet module install puppetlabs-concat


### PR DESCRIPTION
Provisioning (ad hoc) Keycloak test instances that use postgresql fails without
this module.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.net>