### PR TITLE
Remove prefixes from socket-binding-groups

### DIFF
--- a/templates/config.cli/01-https-proxy.epp
+++ b/templates/config.cli/01-https-proxy.epp
@@ -10,12 +10,12 @@ if (result.proxy-address-forwarding != true) of <%= $prefix -%>/subsystem=undert
 end-if
 <%# use ha sockets in domain mode -%>
 <% if $operating_mode != 'domain' { -%>
-if (outcome != success) of <%= $prefix -%>/socket-binding-group=standard-sockets/socket-binding=proxy-https:read-resource
-<%= $prefix -%>/socket-binding-group=standard-sockets/socket-binding=proxy-https:add(port=443)
+if (outcome != success) of /socket-binding-group=standard-sockets/socket-binding=proxy-https:read-resource
+/socket-binding-group=standard-sockets/socket-binding=proxy-https:add(port=443)
 end-if
 <% } else { -%>
-if (outcome != success) of <%= $prefix -%>/socket-binding-group=ha-sockets/socket-binding=proxy-https:read-resource
-<%= $prefix -%>/socket-binding-group=ha-sockets/socket-binding=proxy-https:add(port=443)
+if (outcome != success) of /socket-binding-group=ha-sockets/socket-binding=proxy-https:read-resource
+/socket-binding-group=ha-sockets/socket-binding=proxy-https:add(port=443)
 end-if
 <% end } -%>
 if (result.redirect-socket != proxy-https) of <%= $prefix -%>/subsystem=undertow/server=default-server/http-listener=default:read-resource


### PR DESCRIPTION
This fixes the problem of using wrong address for socket-binding-groups in 01-https-proxy.epp caused by misuse of prefixes. This only affected domain mode, but was also wrong, albeit working for standalone mode. 

Signed-off-by: Kibahop <petri.lammi@puppeteers.net>