### PR TITLE
Add extra configurations to keycloak realm

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3143,6 +3143,12 @@ The following properties are available in the `keycloak_realm` type.
 
 accessCodeLifespan
 
+##### `access_code_lifespan_login`
+
+Unit : minutes
+
+accessCodeLifespanLogin
+
 ##### `access_code_lifespan_user_action`
 
 accessCodeLifespanUserAction
@@ -3182,6 +3188,18 @@ Default value: `false`
 adminTheme
 
 Default value: `keycloak`
+
+##### `action_token_generated_by_admin_lifespan`
+
+Unit : minutes
+
+actionTokenGeneratedByAdminLifespan
+
+##### `action_token_generated_by_user_lifespan`
+
+Unit : minutes
+
+actionTokenGeneratedByUserLifespan
 
 ##### `browser_flow`
 
@@ -3292,6 +3310,26 @@ Valid values: ``true``, ``false``
 loginWithEmailAllowed
 
 Default value: `true`
+
+##### `offline_session_idle_timeout`
+
+Unit : seconds
+
+offlineSessionIdleTimeout
+
+##### `offline_session_max_lifespan`
+
+Unit : seconds
+
+offlineSessionMaxLifespan
+
+##### `offline_session_max_lifespan_enabled`
+
+Valid values: ``true``, ``false``
+
+offlineSessionMaxLifespanEnabled
+
+Default value: `false`
 
 ##### `optional_client_scopes`
 

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -84,6 +84,10 @@ Manage Keycloak realms
     desc 'accessCodeLifespan'
   end
 
+  newproperty(:access_code_lifespan_login, parent: PuppetX::Keycloak::IntegerProperty) do
+    desc 'accessCodeLifespanLogin'
+  end
+
   newproperty(:access_code_lifespan_user_action, parent: PuppetX::Keycloak::IntegerProperty) do
     desc 'accessCodeLifespanUserAction'
   end
@@ -94,6 +98,22 @@ Manage Keycloak realms
 
   newproperty(:access_token_lifespan_for_implicit_flow, parent: PuppetX::Keycloak::IntegerProperty) do
     desc 'accessTokenLifespanForImplicitFlow'
+  end
+
+  newproperty(:action_token_generated_by_admin_lifespan, parent: PuppetX::Keycloak::IntegerProperty) do
+    desc 'actionTokenGeneratedByAdminLifespan'
+  end
+
+  newproperty(:action_token_generated_by_user_lifespan, parent: PuppetX::Keycloak::IntegerProperty) do
+    desc 'actionTokenGeneratedByUserLifespan'
+  end
+
+  newproperty(:offline_session_idle_timeout, parent: PuppetX::Keycloak::IntegerProperty) do
+    desc 'offlineSessionIdleTimeout'
+  end
+
+  newproperty(:offline_session_max_lifespan, parent: PuppetX::Keycloak::IntegerProperty) do
+    desc 'offlineSessionMaxLifespan'
   end
 
   newproperty(:enabled, boolean: true) do
@@ -118,6 +138,12 @@ Manage Keycloak realms
     desc 'loginWithEmailAllowed'
     newvalues(:true, :false)
     defaultto :true
+  end
+
+  newproperty(:offline_session_max_lifespan_enabled, boolean: true) do
+    desc 'offlineSessionMaxLifespanEnabled'
+    newvalues(:true, :false)
+    defaultto :false
   end
 
   newproperty(:reset_password_allowed, boolean: true) do

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -49,7 +49,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     events_listeners: ['jboss-logging'],
     admin_events_enabled: :false,
     admin_events_details_enabled: :false,
-    offline_session_max_lifespan_enabled: false,
+    offline_session_max_lifespan_enabled: :false,
   }
 
   describe 'basic properties' do

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -49,6 +49,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     events_listeners: ['jboss-logging'],
     admin_events_enabled: :false,
     admin_events_details_enabled: :false,
+    offline_session_max_lifespan_enabled: false,
   }
 
   describe 'basic properties' do
@@ -96,9 +97,14 @@ describe Puppet::Type.type(:keycloak_realm) do
       :sso_session_idle_timeout,
       :sso_session_max_lifespan,
       :access_code_lifespan,
+      :access_code_lifespan_login,
       :access_code_lifespan_user_action,
       :access_token_lifespan,
       :access_token_lifespan_for_implicit_flow,
+      :action_token_generated_by_admin_lifespan,
+      :action_token_generated_by_user_lifespan,
+      :offline_session_idle_timeout,
+      :offline_session_max_lifespan,
       :smtp_server_port,
     ].each do |p|
       it "should accept a #{p}" do
@@ -129,6 +135,7 @@ describe Puppet::Type.type(:keycloak_realm) do
       :smtp_server_starttls,
       :smtp_server_ssl,
       :brute_force_protected,
+      :offline_session_max_lifespan_enabled,
     ].each do |p|
       it "should accept true for #{p}" do
         config[p] = true


### PR DESCRIPTION
Add support of :
- `accessCodeLifespanLogin`
- `actionTokenGeneratedByAdminLifespan`
- `actionTokenGeneratedByUserLifespan`
- `offlineSessionIdleTimeout`
- `offlineSessionMaxLifespan`
- `offlineSessionMaxLifespanEnabled`

Tested on Keycloak 11