### PR TITLE
Fix assigning management interfaces to logical interfaces in domain mode

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -318,8 +318,8 @@ class keycloak::config {
         changes   => [
           # lint:ignore:single_quote_string_with_variables
           'set native-interface/#attribute/security-realm ManagementRealm',
-          'set native-interface/socket/#attribute/port ${jboss.management.native.port:9999}',
           'set native-interface/socket/#attribute/interface management',
+          'set native-interface/socket/#attribute/port ${jboss.management.native.port:9999}',
           'set http-interface/socket/#attribute/interface private',
           # lint:endignore
         ],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -310,12 +310,14 @@ class keycloak::config {
       }
 
       # Assing management interfaces to logical interfaces
-      augeas { 'assign-management-interaces-master':
+      augeas { 'assign-management-interfaces-master':
         incl      => "${keycloak::install_base}/domain/configuration/host-master.xml",
         context   => "/files${keycloak::install_base}/domain/configuration/host-master.xml/host/management/management-interfaces",
         load_path => '/opt/puppetlabs/puppet/share/augeas/lenses/dist',
         lens      => 'Xml.lns',
         changes   => [
+          'set native-interface/#attribute/security-realm ManagementRealm',
+          'set native-interface/socket/#attribute/port ${jboss.management.native.port:9999}',
           'set native-interface/socket/#attribute/interface management',
           'set http-interface/socket/#attribute/interface private',
         ],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -316,10 +316,12 @@ class keycloak::config {
         load_path => '/opt/puppetlabs/puppet/share/augeas/lenses/dist',
         lens      => 'Xml.lns',
         changes   => [
+          # lint:ignore:single_quote_string_with_variables
           'set native-interface/#attribute/security-realm ManagementRealm',
           'set native-interface/socket/#attribute/port ${jboss.management.native.port:9999}',
           'set native-interface/socket/#attribute/interface management',
           'set http-interface/socket/#attribute/interface private',
+          # lint:endignore
         ],
         notify    => Class['keycloak::service'],
       }


### PR DESCRIPTION
In newest Keycloaks (>10), the stock host-master.xml does not include the native interface definition in management-interfaces. Fix assign-management-interfaces-master augeas resource. 