### PR TITLE
Fix invalid puppet modules on vagrant provision & add kernel upgrade

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.define "keycloak", primary: true, autostart: true do |ood|
     ood.vm.box = "centos/7"
+    ood.vbguest.installer_options = { allow_kernel_upgrade: true }
     ood.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
     ood.vm.provision "shell", inline: <<-SHELL
       rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm

--- a/vagrant-common.sh
+++ b/vagrant-common.sh
@@ -2,6 +2,7 @@
 #
 # Common part of the Vagrant provisioning
 #
+ln -s /vagrant /etc/puppetlabs/code/environments/production/modules/keycloak
 puppet module install puppetlabs-stdlib
 puppet module install puppetlabs-mysql
 puppet module install puppetlabs-postgresql
@@ -10,5 +11,4 @@ puppet module install puppetlabs-java_ks
 puppet module install puppetlabs-concat
 puppet module install puppet-archive
 puppet module install camptocamp-systemd
-ln -s /vagrant /etc/puppetlabs/code/environments/production/modules/keycloak
 puppet apply /vagrant/spec/fixtures/test.pp


### PR DESCRIPTION
The modules would exist in an invalid state as shown:

/etc/puppetlabs/code/environments/production/modules
└─┬ treydock-keycloak (v7.7.0)
  ├── puppetlabs-stdlib (v8.0.0)  invalid
  ├── puppetlabs-mysql (v12.0.1)  invalid
  ├─┬ puppetlabs-postgresql (v7.4.1)
  │ ├── puppetlabs-apt (v8.2.0)
  │ └── puppetlabs-concat (v7.1.1)
  ├── puppetlabs-java (v1.3.0)  invalid
  ├── puppetlabs-java_ks (v4.2.0)
  ├── puppetlabs-augeas_core (v1.1.2)
  ├── puppetlabs-yumrepo_core (v1.0.7)
  ├── puppet-archive (v6.0.1)  invalid
  └── camptocamp-systemd (v0.4.0)

Keycloak module doesn't load properly because of this and am unable to access through web interface. 