### PR TITLE
Fix invalid module dependency versions

### DIFF
--- a/vagrant-common.sh
+++ b/vagrant-common.sh
@@ -2,6 +2,7 @@
 #
 # Common part of the Vagrant provisioning
 #
+ln -s /vagrant /etc/puppetlabs/code/environments/production/modules/keycloak
 puppet module install puppetlabs-stdlib
 puppet module install puppetlabs-mysql
 puppet module install puppetlabs-postgresql
@@ -10,5 +11,4 @@ puppet module install puppetlabs-java_ks
 puppet module install puppetlabs-concat
 puppet module install puppet-archive
 puppet module install camptocamp-systemd
-ln -s /vagrant /etc/puppetlabs/code/environments/production/modules/keycloak
 puppet apply /vagrant/spec/fixtures/test.pp


### PR DESCRIPTION
On `vagrant up` provisioning would cause installed puppet modules to be in an incorect state:
/etc/puppetlabs/code/environments/production/modules
└─┬ treydock-keycloak (v7.7.0)
  ├── puppetlabs-stdlib (v8.0.0)  invalid
  ├── puppetlabs-mysql (v12.0.1)  invalid
  ├─┬ puppetlabs-postgresql (v7.4.1)
  │ ├── puppetlabs-apt (v8.2.0)
  │ └── puppetlabs-concat (v7.1.1)
  ├── puppetlabs-java (v1.3.0)  invalid
  ├── puppetlabs-java_ks (v4.2.0)
  ├── puppetlabs-augeas_core (v1.1.2)
  ├── puppetlabs-yumrepo_core (v1.0.7)
  ├── puppet-archive (v6.0.1)  invalid
  └── camptocamp-systemd (v0.4.0)

This would cause keycloak to not be loaded properly