### PR TITLE
Fix centos/7 in Vagrant failing

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.define "keycloak", primary: true, autostart: true do |ood|
     ood.vm.box = "centos/7"
+    ood.vbguest.installer_options = { allow_kernel_upgrade: true }
     ood.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
     ood.vm.provision "shell", inline: <<-SHELL
       rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm


### PR DESCRIPTION
Provisioning failed when trying to apply kernel-devel package and mounting /vagrant would break
```
--- snip ---
No package kernel-devel-3.10.0-1127.el7.x86_64 available.
Error: Nothing to do
Unmounting Virtualbox Guest Additions ISO from: /mnt
umount: /mnt: not mounted
--- snip ---
Vagrant assumes that this means the command failed!

umount /mnt

Stdout from the command:

Stderr from the command:

umount: /mnt: not mounted
```
After the initial fail, have to run `vagrant up keycloak` once again which would cause the keycloak module to error due to /vagrant not being mounted. 