### PR TITLE
set keycloak_server in keycloak_conn_validator from 'localhost' to $service_bind_address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -483,8 +483,14 @@ class keycloak (
     Class['keycloak::sssd'] ~> Class['keycloak::service']
   }
 
+  if $service_bind_address == '0.0.0.0' {
+    $validator_keycloak_server = '127.0.0.1'
+  } else {
+    $validator_keycloak_server = $service_bind_address
+  }
+
   keycloak_conn_validator { 'keycloak':
-    keycloak_server => $service_bind_address,
+    keycloak_server => $validator_keycloak_server,
     keycloak_port   => $http_port,
     use_ssl         => false,
     timeout         => 60,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -484,7 +484,7 @@ class keycloak (
   }
 
   keycloak_conn_validator { 'keycloak':
-    keycloak_server => 'localhost',
+    keycloak_server => $service_bind_address,
     keycloak_port   => $http_port,
     use_ssl         => false,
     timeout         => 60,


### PR DESCRIPTION
Fixes `keycloak_conn_validator` when `service_bind_address` is set to different value then `0.0.0.0` or `127.0.0.1`.  [fixes #215]