### PR TITLE
Fix issues with install_base /opt/keycloak

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,9 +2,11 @@
 class keycloak::config {
   assert_private()
 
-  file { '/opt/keycloak':
-    ensure => 'link',
-    target => $keycloak::install_base,
+  if $keycloak::install_base != '/opt/keycloak' {
+    file { '/opt/keycloak':
+      ensure => 'link',
+      target => $keycloak::install_base,
+    }
   }
 
   # Template uses:


### PR DESCRIPTION
When using my own packages, IMVHO it makes more sense to use `/opt/keycloak` instead of `/opt/keycloak-$version`. So I need to set `$keycloak::install_dir` to `/opt/keycloak`, but this conflicts with the symlink in `manifests/config.pp`, so this PR fixes that.