### PR TITLE
Realm role mapping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     * [Keycloak](#keycloak)
     * [Deploy SPI](#deploy-spi)
     * [keycloak_realm](#keycloak_realm)
+    * [keycloak_role_mapping](#keycloak_role_mapping)
     * [keycloak_ldap_user_provider](#keycloak_ldap_user_provider)
     * [keycloak_ldap_mapper](#keycloak_ldap_mapper)
     * [keycloak_sssd_user_provider](#keycloak_sssd_user_provider)
@@ -281,6 +282,23 @@ keycloak_realm { 'test':
 ```
 
 **NOTE:** If the flow properties such as `browser_flow` are changed from their defaults then this value will not be set when a realm is first created. The value will also not be updated if the flow does not exist. For new realms you will have to run Puppet twice in order to create the flows then update the realm setting.
+
+### keycloak\_role\_mapping
+
+Manage realm role mappings for users and groups. Example:
+
+    keycloak_role_mapping { 'roles for john on master':
+      realm       => 'master',
+      name        => 'john',
+      realm_roles => ['role1', 'role2'],
+    }
+    
+    keycloak_role_mapping { 'roles for mygroup on master':
+      realm        => 'master',
+      name         => 'mygroup',
+      group        => true,
+      realm_roles  => ['role1'],
+    }
 
 ### keycloak\_ldap\_user_provider
 

--- a/lib/puppet/provider/keycloak_role_mapping/kcadm.rb
+++ b/lib/puppet/provider/keycloak_role_mapping/kcadm.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:keycloak_role_mapping).provide(:kcadm, parent: Puppet::Provid
   end
 
   def realm_roles
-    @active_realm_roles = []
+    active_realm_roles = []
 
     output = kcadm('get-roles', nil, resource[:realm], nil, nil, false, opt => resource[:name])
     begin
@@ -18,16 +18,16 @@ Puppet::Type.type(:keycloak_role_mapping).provide(:kcadm, parent: Puppet::Provid
     end
 
     data.each do |d|
-      @active_realm_roles << d['name']
+      active_realm_roles << d['name']
     end
-    @active_realm_roles
+    active_realm_roles
   end
 
   def realm_roles=(_value)
-    removed_roles = @active_realm_roles.reject { |role| resource[:realm_roles].include?(role) }
+    removed_roles = realm_roles.reject { |role| resource[:realm_roles].include?(role) }
     remove_roles(removed_roles)
 
-    new_roles = resource[:realm_roles].reject { |role| @active_realm_roles.include?(role) }
+    new_roles = resource[:realm_roles].reject { |role| realm_roles.include?(role) }
     add_roles(new_roles)
   end
 

--- a/lib/puppet/provider/keycloak_role_mapping/kcadm.rb
+++ b/lib/puppet/provider/keycloak_role_mapping/kcadm.rb
@@ -1,0 +1,43 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'keycloak_api'))
+
+Puppet::Type.type(:keycloak_role_mapping).provide(:kcadm, parent: Puppet::Provider::KeycloakAPI) do
+  desc ''
+
+  def opt
+    (resource[:group] == :true) ? 'gname' : 'uusername'
+  end
+
+  def realm_roles
+    @active_realm_roles = []
+
+    output = kcadm('get-roles', nil, resource[:realm], nil, nil, false, opt => resource[:name])
+    begin
+      data = JSON.parse(output)
+    rescue JSON::ParserError
+      Puppet.debug('Unable to parse output from kcadm get-roles')
+    end
+
+    data.each do |d|
+      @active_realm_roles << d['name']
+    end
+    @active_realm_roles
+  end
+
+  def realm_roles=(_value)
+    removed_roles = @active_realm_roles.reject { |role| resource[:realm_roles].include?(role) }
+    remove_roles(removed_roles)
+
+    new_roles = resource[:realm_roles].reject { |role| @active_realm_roles.include?(role) }
+    add_roles(new_roles)
+  end
+
+  def remove_roles(roles)
+    return if roles.empty?
+    kcadm('remove-roles', '', resource[:realm], nil, nil, false, opt => resource[:name], rolename: roles)
+  end
+
+  def add_roles(roles)
+    return if roles.empty?
+    kcadm('add-roles', '', resource[:realm], nil, nil, false, opt => resource[:name], rolename: roles)
+  end
+end

--- a/lib/puppet/type/keycloak_role_mapping.rb
+++ b/lib/puppet/type/keycloak_role_mapping.rb
@@ -1,0 +1,36 @@
+require_relative '../../puppet_x/keycloak/type'
+require_relative '../../puppet_x/keycloak/array_property'
+
+Puppet::Type.newtype(:keycloak_role_mapping) do
+  desc <<-DESC
+Attach realm roles to users and groups
+@example Ensure that a user has the defined realm roles
+  keycloak_role_mapping { 'john-offline_access':
+    realm       => 'test',
+    name        => 'john',
+    realm_roles => ['offline_access'],
+  }
+  DESC
+
+  extend PuppetX::Keycloak::Type
+  add_autorequires
+
+  newparam(:name, namevar: true) do
+    desc '--uusername/--gname'
+  end
+
+  newparam(:group, boolean: true) do
+    desc 'is this a group instead of a user'
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newparam(:realm) do
+    desc 'realm'
+  end
+
+  newproperty(:realm_roles, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
+    desc 'realm roles'
+    defaultto []
+  end
+end

--- a/spec/acceptance/11_role_mapping_spec.rb
+++ b/spec/acceptance/11_role_mapping_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper_acceptance'
+
+describe 'keycloak_role_mapping:', if: RSpec.configuration.keycloak_full do
+  context 'removes role mappings for admin' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_role_mapping { 'admin':
+        realm       => 'master',
+	name        => 'admin',
+	group       => false,
+	realm_roles => ['admin'],
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'has removed role mappings for admin' do
+      scp_to hosts, 'spec/acceptance/get_role_mappings.rb', '/tmp'
+
+      on hosts, '/tmp/get_role_mappings.rb users' do
+        data = JSON.parse(stdout)
+        expect(data.sort).to eq(['admin'])
+      end
+    end
+  end
+
+  context 'adds role mappings for admin' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_role_mapping { 'admin':
+        realm       => 'master',
+	name        => 'admin',
+	group       => false,
+	realm_roles => ['admin', 'offline_access'],
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'has added role mappings for admin' do
+      scp_to hosts, 'spec/acceptance/get_role_mappings.rb', '/tmp'
+
+      on hosts, '/tmp/get_role_mappings.rb users' do
+        data = JSON.parse(stdout)
+        expect(data.sort).to eq(['admin', 'offline_access'])
+      end
+    end
+  end
+
+  context 'adds role mappings for testgroup' do
+    it 'has added testgroup' do
+      on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh create groups -r master -s name=testgroup'
+    end
+
+    it 'runs successfully' do
+      pp = <<-EOS
+      include mysql::server
+      class { 'keycloak':
+        datasource_driver => 'mysql',
+      }
+      keycloak_role_mapping { 'testgroup':
+        realm       => 'master',
+	name        => 'testgroup',
+	group       => true,
+	realm_roles => ['admin'],
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'has added role mappings for testgroup' do
+      scp_to hosts, 'spec/acceptance/get_role_mappings.rb', '/tmp'
+
+      on hosts, '/tmp/get_role_mappings.rb groups' do
+        data = JSON.parse(stdout)
+        expect(data.sort).to eq(['admin'])
+      end
+    end
+  end
+end

--- a/spec/acceptance/get_role_mappings.rb
+++ b/spec/acceptance/get_role_mappings.rb
@@ -1,0 +1,29 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+#
+# Simple script to enable testing the functionality of keycloak_role_mapping provider.
+# Not expected to be useful outside of the Beaker tests, nor to be robust against
+# unexpected situations.
+#
+require 'json'
+
+if ARGV[0] == 'groups'
+  path = 'groups'
+  filter = 'name=testgroup'
+elsif ARGV[0] == 'users'
+  path = 'users'
+  filter = 'username=admin'
+else
+  puts 'ERROR: must pass "users" or "groups" as parameter'
+  exit 1
+end
+
+# Get the ID of the user or group
+uid = JSON.parse(`/opt/keycloak/bin/kcadm-wrapper.sh get #{path}?#{filter} -r master`)[0]['id']
+
+# Get role realm role mappings using the ID
+realm_role_mappings = []
+JSON.parse(`/opt/keycloak/bin/kcadm-wrapper.sh get #{path}/#{uid}/role-mappings -r master`)['realmMappings'].each do |mapping|
+  realm_role_mappings << mapping['name']
+end
+
+p realm_role_mappings

--- a/spec/unit/puppet/provider/keycloak_role_mapping/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_role_mapping/kcadm_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:keycloak_role_mapping).provider(:kcadm) do
+  let(:type) do
+    Puppet::Type.type(:keycloak_role_mapping)
+  end
+
+  describe 'add realm roles' do
+    let(:resource) do
+      type.new(name: 'role-mapping',
+               group: false,
+               realm: 'test',
+               realm_roles: ['a', 'b', 'c'])
+    end
+
+    it 'has added realm role' do
+      allow(resource.provider).to receive(:kcadm)
+      allow(resource.provider).to receive(:realm_roles).and_return(['a', 'b'])
+      expect(resource.provider).to receive(:add_roles).with(['c'])
+      resource.provider.realm_roles= ['a', 'b', 'c'] # rubocop:disable Layout/SpaceAroundOperators
+    end
+  end
+
+  describe 'remove realm roles' do
+    let(:resource) do
+      type.new(name: 'role-mapping',
+               group: false,
+               realm: 'test',
+               realm_roles: ['a'])
+    end
+
+    it 'has removed realm role' do
+      allow(resource.provider).to receive(:kcadm)
+      allow(resource.provider).to receive(:realm_roles).and_return(['a', 'b'])
+      expect(resource.provider).to receive(:remove_roles).with(['b'])
+      resource.provider.realm_roles= ['a'] # rubocop:disable Layout/SpaceAroundOperators
+    end
+  end
+end

--- a/spec/unit/puppet/type/keycloak_role_mapping_spec.rb
+++ b/spec/unit/puppet/type/keycloak_role_mapping_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:keycloak_role_mapping) do
+  let(:default_config) do
+    {
+      name: 'test',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
+  end
+
+  it 'adds to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource resource
+    }.not_to raise_error
+  end
+
+  it 'has a name' do
+    expect(resource[:name]).to eq('test')
+  end
+
+  defaults = {
+    group: :false,
+  }
+
+  describe 'basic properties' do
+    # Test basic properties
+    [
+      :realm,
+      :name,
+    ].each do |p|
+      it "should accept a #{p}" do
+        config[p] = 'foo'
+        expect(resource[p]).to eq('foo')
+      end
+      next unless defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
+  end
+
+  describe 'boolean properties' do
+    # Test boolean properties
+    [
+      :group,
+    ].each do |p|
+      it "should accept true for #{p}" do
+        config[p] = true
+        expect(resource[p]).to eq(:true)
+      end
+      it "should accept true for #{p} string" do
+        config[p] = 'true'
+        expect(resource[p]).to eq(:true)
+      end
+      it "should accept false for #{p}" do
+        config[p] = false
+        expect(resource[p]).to eq(:false)
+      end
+      it "should accept false for #{p} string" do
+        config[p] = 'false'
+        expect(resource[p]).to eq(:false)
+      end
+      it "should not accept strings for #{p}" do
+        config[p] = 'foo'
+        expect {
+          resource
+        }.to raise_error(%r{foo})
+      end
+      next unless defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
+  end
+
+  describe 'array properties' do
+    # Array properties
+    [
+      :realm_roles,
+    ].each do |p|
+      it "should accept array for #{p}" do
+        config[p] = ['foo', 'bar']
+        expect(resource[p]).to eq(['foo', 'bar'])
+      end
+      next unless defaults[p]
+      it "should have default for #{p}" do
+        expect(resource[p]).to eq(defaults[p])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is simplified version of the earlier PR (https://github.com/treydock/puppet-module-keycloak/pull/175). All it does is add realm role mapping support for users and groups.