### PR TITLE
Fix authorization services data corruption on unrelated client changes

### DIFF
--- a/lib/puppet/provider/keycloak_client/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client/kcadm.rb
@@ -327,6 +327,10 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
 
       data = {}
       data[:clientId] = resource[:client_id]
+      if resource[:authorization_services_enabled] == :true
+        data[:authorizationServicesEnabled] = true
+        data[:serviceAccountsEnabled] = true
+      end
       data[:authenticationFlowBindingOverrides] = {}
       type_properties.each do |property|
         next if [:default_client_scopes, :optional_client_scopes, :roles].include?(property)


### PR DESCRIPTION
Disabling authorization services for a client results, by design, removal of
all the authorization data for that client. Before this commit any property
changes (e.g. changing root_url) to a keycloak_client would generate a payload
that did not have authorizationServicesEnabled included. Keycloak interpreted
such a payload as "disable authorization services for the client", which in
turn resulted in unintentional destruction of the client's authorization data.
This commit fixes that behavior and adds tests to prevent future regressions.