### PR TITLE
fix profile.properties file path in domain mode

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,12 +49,13 @@ class keycloak::config {
       $_server_conf_dir
     ]
 
-    file { $_dirs:
-      ensure => 'directory',
-      owner  => $keycloak::user,
-      group  => $keycloak::group,
-      mode   => '0755',
-    }
+  }
+
+  file { $_dirs:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0755',
   }
 
   exec { 'create-keycloak-admin':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,12 +56,18 @@ class keycloak::config {
     }
   }
 
+  file { $_server_conf_dir:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0750',
+  }
+
   exec { 'create-keycloak-admin':
     command => "${_add_user_keycloak_cmd} ${_add_user_keycloak_args} && touch ${_add_user_keycloak_state}",
     creates => $_add_user_keycloak_state,
     notify  => Class['keycloak::service'],
     user    => $keycloak::user,
-    require => File[$_server_conf_dir],
   }
 
   if $keycloak::operating_mode == 'domain' {
@@ -243,13 +249,6 @@ class keycloak::config {
     line   => "JAVA_OPTS=\"${_java_opts}\"",
     match  => '^JAVA_OPTS=',
     notify => Class['keycloak::service'],
-  }
-
-  file { $_server_conf_dir:
-    ensure => 'directory',
-    owner  => $keycloak::user,
-    group  => $keycloak::group,
-    mode   => '0750',
   }
 
   file { "${_server_conf_dir}/profile.properties":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,9 +38,6 @@ class keycloak::config {
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master"
     $_java_opts_path = "${keycloak::install_base}/bin/standalone.conf"
 
-    $_dirs = [
-      $_server_conf_dir
-    ]
   } else {
     $_server_conf_dir = "${keycloak::install_base}/domain/servers/${keycloak::server_name}/configuration"
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master --sc ${_server_conf_dir}/" # lint:ignore:140chars

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,8 +34,8 @@ class keycloak::config {
   $_add_user_keycloak_state = "${keycloak::install_base}/.create-keycloak-admin-${keycloak::datasource_driver}"
 
   if $::keycloak::operating_mode != 'domain' {
+    $_server_conf_dir = "${keycloak::install_base}/standalone/configuration"
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master"
-    $_subdir = 'standalone'
     $_java_opts_path = "${keycloak::install_base}/bin/standalone.conf"
   } else {
     $_server_conf_dir = "${keycloak::install_base}/domain/servers/${keycloak::server_name}/configuration"
@@ -244,7 +244,7 @@ class keycloak::config {
     notify => Class['keycloak::service'],
   }
 
-  file { ${_server_conf_dir}:
+  file { $_server_conf_dir:
     ensure => 'directory',
     owner  => $keycloak::user,
     group  => $keycloak::group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,8 +47,8 @@ class keycloak::config {
     $_java_opts_path = "${keycloak::install_base}/bin/domain.conf"
 
     $_dirs = [
-      "${keycloak::install_base}/domain/servers",
-      "${keycloak::install_base}/domain/servers/${keycloak::server_name}",
+      dirname(dirname($_server_conf_dir)),
+      dirname($_server_conf_dir),
       $_server_conf_dir
     ]
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,13 +48,12 @@ class keycloak::config {
       dirname($_server_conf_dir)
     ]
 
-  }
-
-  file { $_dirs:
-    ensure => 'directory',
-    owner  => $keycloak::user,
-    group  => $keycloak::group,
-    mode   => '0755',
+    file { $_dirs:
+      ensure => 'directory',
+      owner  => $keycloak::user,
+      group  => $keycloak::group,
+      mode   => '0755',
+    }
   }
 
   exec { 'create-keycloak-admin':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,8 +45,7 @@ class keycloak::config {
 
     $_dirs = [
       dirname(dirname($_server_conf_dir)),
-      dirname($_server_conf_dir),
-      $_server_conf_dir
+      dirname($_server_conf_dir)
     ]
 
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,10 @@ class keycloak::config {
     $_server_conf_dir = "${keycloak::install_base}/standalone/configuration"
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master"
     $_java_opts_path = "${keycloak::install_base}/bin/standalone.conf"
+
+    $_dirs = [
+      $_server_conf_dir
+    ]
   } else {
     $_server_conf_dir = "${keycloak::install_base}/domain/servers/${keycloak::server_name}/configuration"
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master --sc ${_server_conf_dir}/" # lint:ignore:140chars
@@ -45,15 +49,16 @@ class keycloak::config {
     $_dirs = [
       "${keycloak::install_base}/domain/servers",
       "${keycloak::install_base}/domain/servers/${keycloak::server_name}",
-      "${keycloak::install_base}/domain/servers/${keycloak::server_name}/configuration",
+      $_server_conf_dir
     ]
 
-    file { $_dirs:
-      ensure => 'directory',
-      owner  => $keycloak::user,
-      group  => $keycloak::group,
-      mode   => '0755',
-    }
+  }
+
+  file { $_dirs:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0755',
   }
 
   exec { 'create-keycloak-admin':
@@ -242,13 +247,6 @@ class keycloak::config {
     line   => "JAVA_OPTS=\"${_java_opts}\"",
     match  => '^JAVA_OPTS=',
     notify => Class['keycloak::service'],
-  }
-
-  file { $_server_conf_dir:
-    ensure => 'directory',
-    owner  => $keycloak::user,
-    group  => $keycloak::group,
-    mode   => '0750',
   }
 
   file { "${_server_conf_dir}/profile.properties":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -245,6 +245,13 @@ class keycloak::config {
     notify => Class['keycloak::service'],
   }
 
+  file { $_server_conf_dir:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0750',
+  }
+
   file { "${_server_conf_dir}/profile.properties":
     ensure  => 'file',
     owner   => $keycloak::user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,13 +52,12 @@ class keycloak::config {
       $_server_conf_dir
     ]
 
-  }
-
-  file { $_dirs:
-    ensure => 'directory',
-    owner  => $keycloak::user,
-    group  => $keycloak::group,
-    mode   => '0755',
+    file { $_dirs:
+      ensure => 'directory',
+      owner  => $keycloak::user,
+      group  => $keycloak::group,
+      mode   => '0755',
+    }
   }
 
   exec { 'create-keycloak-admin':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,7 +40,6 @@ class keycloak::config {
   } else {
     $_server_conf_dir = "${keycloak::install_base}/domain/servers/${keycloak::server_name}/configuration"
     $_add_user_keycloak_args = "--user ${keycloak::admin_user} --password ${keycloak::admin_user_password} --realm master --sc ${_server_conf_dir}/" # lint:ignore:140chars
-    $_subdir = 'domain'
     $_java_opts_path = "${keycloak::install_base}/bin/domain.conf"
 
     $_dirs = [
@@ -245,14 +244,14 @@ class keycloak::config {
     notify => Class['keycloak::service'],
   }
 
-  file { "${keycloak::install_base}/${_subdir}/configuration":
+  file { ${_server_conf_dir}:
     ensure => 'directory',
     owner  => $keycloak::user,
     group  => $keycloak::group,
     mode   => '0750',
   }
 
-  file { "${keycloak::install_base}/${_subdir}/configuration/profile.properties":
+  file { "${_server_conf_dir}/profile.properties":
     ensure  => 'file',
     owner   => $keycloak::user,
     group   => $keycloak::group,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,6 +61,7 @@ class keycloak::config {
     creates => $_add_user_keycloak_state,
     notify  => Class['keycloak::service'],
     user    => $keycloak::user,
+    require => File[$_server_conf_dir],
   }
 
   if $keycloak::operating_mode == 'domain' {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,18 +56,12 @@ class keycloak::config {
     }
   }
 
-  file { $_server_conf_dir:
-    ensure => 'directory',
-    owner  => $keycloak::user,
-    group  => $keycloak::group,
-    mode   => '0750',
-  }
-
   exec { 'create-keycloak-admin':
     command => "${_add_user_keycloak_cmd} ${_add_user_keycloak_args} && touch ${_add_user_keycloak_state}",
     creates => $_add_user_keycloak_state,
     notify  => Class['keycloak::service'],
     user    => $keycloak::user,
+    require => File[$_server_conf_dir],
   }
 
   if $keycloak::operating_mode == 'domain' {
@@ -249,6 +243,13 @@ class keycloak::config {
     line   => "JAVA_OPTS=\"${_java_opts}\"",
     match  => '^JAVA_OPTS=',
     notify => Class['keycloak::service'],
+  }
+
+  file { $_server_conf_dir:
+    ensure => 'directory',
+    owner  => $keycloak::user,
+    group  => $keycloak::group,
+    mode   => '0750',
   }
 
   file { "${_server_conf_dir}/profile.properties":


### PR DESCRIPTION
According to official documentation, profile.properties must be placed under:

- standalone/configuration/profile.properties for standalone mode
- or domain/servers/server-one/configuration/profile.properties for server-one in domain mode.