### PR TITLE
Allow to configure LDAP kerberos through the module

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2680,6 +2680,12 @@ keycloak_ldap_user_provider { 'LDAP on test':
 
 The following properties are available in the `keycloak_ldap_user_provider` type.
 
+##### `allow_kerberos_authentication`
+
+Valid values: ``true``, ``false``
+
+allowKerberosAuthentication
+
 ##### `auth_type`
 
 Valid values: `none`, `simple`
@@ -2758,6 +2764,14 @@ importEnabled
 
 Default value: `true`
 
+##### `kerberos_realm`
+
+kerberosRealm
+
+##### `key_tab`
+
+keyTab
+
 ##### `priority`
 
 priority
@@ -2775,6 +2789,10 @@ Default value: `uid`
 Valid values: `one`, `one_level`, `subtree`, `1`, `2`, `1`, `2`
 
 searchScope
+
+##### `server_principal`
+
+serverPrincipal
 
 ##### `sync_registrations`
 

--- a/lib/puppet/type/keycloak_ldap_user_provider.rb
+++ b/lib/puppet/type/keycloak_ldap_user_provider.rb
@@ -161,6 +161,23 @@ Manage Keycloak LDAP user providers
     newvalues(:true, :false)
   end
 
+  newproperty(:allow_kerberos_authentication, boolean: true) do
+    desc 'allowKerberosAuthentication'
+    newvalues(:true, :false)
+  end
+
+  newproperty(:kerberos_realm) do
+    desc 'kerberosRealm'
+  end
+
+  newproperty(:key_tab) do
+    desc 'keyTab'
+  end
+
+  newproperty(:server_principal) do
+    desc 'serverPrincipal'
+  end
+
   newproperty(:user_object_classes, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
     desc 'userObjectClasses'
     defaultto ['inetOrgPerson', 'organizationalPerson']

--- a/spec/unit/puppet/type/keycloak_ldap_user_provider_spec.rb
+++ b/spec/unit/puppet/type/keycloak_ldap_user_provider_spec.rb
@@ -108,6 +108,18 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider) do
     expect(resource[:use_kerberos_for_password_authentication]).to eq(:true)
   end
 
+  it 'allows kerberos configuration' do
+    config[:auth_type] = 'simple'
+    config[:allow_kerberos_authentication] = true
+    config[:kerberos_realm] = 'BAR.COM'
+    config[:key_tab] = '/etc/krb5.keytab'
+    config[:server_principal] = 'host/foo@BAR.COM'
+    expect(resource[:allow_kerberos_authentication]).to eq(:true)
+    expect(resource[:kerberos_realm]).to eq('BAR.COM')
+    expect(resource[:key_tab]).to eq('/etc/krb5.keytab')
+    expect(resource[:server_principal]).to eq('host/foo@BAR.COM')
+  end
+
   it 'does not allow invalid bind_credential' do
     config[:auth_type] = 'simple'
     config[:use_kerberos_for_password_authentication] = 'foo'


### PR DESCRIPTION
Dear maintainer,

It allows to configure the parameters inside the "Kerberos integration" sub menu, for User federations.
the `useKerberosForPasswordAuthentication`, already exist, so it adds:
- `allowKerberosAuthentication`
- `kerberosRealm`
- `keyTab`
- `serverPrincipal`

