### PR TITLE
Do not reassign '$hostname' variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -354,16 +354,16 @@ class keycloak (
       $validator_server = $config['http-host']
     }
   } else {
-    if $config['hostname'] in ['unset', 'UNSET'] {
-      $hostname = $facts['networking']['fqdn']
+    if ! $config['hostname'] {
+      $effective_hostname = $facts['networking']['fqdn']
     } else {
-      $hostname = $config['hostname']
+      $effective_hostname = $config['hostname']
     }
     $wrapper_protocol = 'https'
     $wrapper_port = $config['https-port']
-    $wrapper_address = $hostname
+    $wrapper_address = $effective_hostname
     $validator_port = $config['https-port']
-    $validator_server = $hostname
+    $validator_server = $effective_hostname
     $validator_ssl = true
   }
   $wrapper_server = "${wrapper_protocol}://${wrapper_address}:${wrapper_port}${config['http-relative-path']}"


### PR DESCRIPTION
Addresses issue reported in https://github.com/treydock/puppet-module-keycloak/issues/274#issuecomment-1506531875

```
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Cannot reassign variable '$hostname' (file: /etc/puppetlabs/code/environments/keycloak_21/modules/keycloak/manifests/init.pp, line: 360, column: 17) on node XXXX.bbp.epfl.ch
Warning: Not using cache on failed catalog
```