### PR TITLE
allow absolute path for package_url parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -189,7 +189,7 @@ Default value: `'22.0.0'`
 
 ##### <a name="-keycloak--package_url"></a>`package_url`
 
-Data type: `Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]]`
+Data type: `Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl, Stdlib::Absolutepath]]`
 
 URL of the Keycloak download.
 Default is based on version.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,7 +223,7 @@
 class keycloak (
   Boolean $manage_install       = true,
   String $version               = '22.0.0',
-  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $package_url= undef,
+  Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl, Stdlib::Absolutepath]] $package_url= undef,
   Optional[Stdlib::Absolutepath] $install_dir = undef,
   Array[String[1]] $java_package_dependencies = [],
   Enum['include','class'] $java_declare_method = 'class',


### PR DESCRIPTION
For servers without direct internet access it's usefull to use an absolute file path instead of a download url.