### PR TITLE
Fix #306 - Retrieve parentId by realm name

### DIFF
--- a/spec/unit/puppet/provider/keycloak_ldap_user_provider/kcadm_spec.rb
+++ b/spec/unit/puppet/provider/keycloak_ldap_user_provider/kcadm_spec.rb
@@ -53,6 +53,7 @@ describe Puppet::Type.type(:keycloak_ldap_user_provider).provider(:kcadm) do
     it 'creates a realm' do
       temp = Tempfile.new('keycloak_component')
       allow(Tempfile).to receive(:new).with('keycloak_component').and_return(temp)
+      allow(resource.provider).to receive(:get_parent_id).with('test').and_return('test')
       expect(resource.provider).to receive(:kcadm).with('create', 'components', 'test', temp.path)
       resource.provider.create
       property_hash = resource.provider.instance_variable_get('@property_hash')


### PR DESCRIPTION
This change will fix #306 as it will try to retrieve the uuid of the given realm first and pass it as `parentId`.

It is a quiet similar solution like in https://github.com/treydock/puppet-module-keycloak/blob/master/lib/puppet/provider/keycloak_ldap_mapper/kcadm.rb#L127