### PR TITLE
Bugfix: remove double declaration of "log-level"

### DIFF
--- a/types/configs.pp
+++ b/types/configs.pp
@@ -56,7 +56,6 @@ type Keycloak::Configs = Struct[
     Optional['log-file'] => Stdlib::Absolutepath,
     Optional['log-file-format'] => String[1],
     Optional['log-file-output'] => Enum['default','json'],
-    Optional['log-level'] => String[1],
     Optional['log-gelf-facility'] => String[1],
     Optional['log-gelf-host'] => Stdlib::Host,
     Optional['log-gelf-include-location'] => Boolean,


### PR DESCRIPTION
fixes on Puppet 8.6.0:
Server Error: The key '["log-level"]' is declared more than once (file: /etc/puppetlabs/code/environments/production/modules/keycloak/types/configs.pp, line: 69, column: 27)