### PR TITLE
Implement webauthn extra origins & Raise KeyCloak version to 24.0.5 in acceptance tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,26 +65,17 @@ jobs:
           - "puppet7"
           - "puppet8"
         keycloak_version:
-          - "22.0.0"
-          - "24.0.3"
+          - "24.0.5"
         keycloak_full:
           - "no"
         include:
           - set: "el8"
             puppet: "puppet7"
-            keycloak_version: "22.0.0"
+            keycloak_version: "24.0.5"
             keycloak_full: "yes"
           - set: "el8"
             puppet: "puppet8"
-            keycloak_version: "22.0.0"
-            keycloak_full: "yes"
-          - set: "el8"
-            puppet: "puppet7"
-            keycloak_version: "24.0.3"
-            keycloak_full: "yes"
-          - set: "el8"
-            puppet: "puppet8"
-            keycloak_version: "24.0.3"
+            keycloak_version: "24.0.5"
             keycloak_full: "yes"
     env:
       BUNDLE_WITHOUT: development:release

--- a/.sync.yml
+++ b/.sync.yml
@@ -25,25 +25,16 @@ Rakefile:
       - puppet7
       - puppet8
     keycloak_version:
-      - '22.0.0'
-      - '24.0.3'
+      - '24.0.5'
     keycloak_full: ['no']
   acceptance_includes:
     - set: el8
       puppet: puppet7
-      keycloak_version: '22.0.0'
+      keycloak_version: '24.0.5'
       keycloak_full: 'yes'
     - set: el8
       puppet: puppet8
-      keycloak_version: '22.0.0'
-      keycloak_full: 'yes'
-    - set: el8
-      puppet: puppet7
-      keycloak_version: '24.0.3'
-      keycloak_full: 'yes'
-    - set: el8
-      puppet: puppet8
-      keycloak_version: '24.0.3'
+      keycloak_version: '24.0.5'
       keycloak_full: 'yes'
 .gitignore:
   paths:

--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ For `keycloak_ldap_mapper` ensure the `parent_id` property is set to point to ol
 
 ### Supported Versions of Keycloak
 
-Currently this module supports Keycloak version 12.x.
+Currently this module supports Keycloak version 24.x.
 This module may work on earlier versions but this is the only version tested.
 
 | Keycloak Version | Keycloak Puppet module versions |
-| ---------------- | ------------------------------- |
+|------------------|---------------------------------|
 | 3.x              | 2.x                             |
 | 4.x - 6.x        | 3.x                             |
 | 6.x - 8.x        | 4.x - 5.x                       |
@@ -176,6 +176,8 @@ This module may work on earlier versions but this is the only version tested.
 | 19.x - 21.x      | 9.x                             |
 | 21.x             | 10.x                            |
 | 22.x - 24.x      | 11.x                            |
+| 24.x - 25.x      | 12.x                            |
+| -----------------|---------------------------------|
 
 ## Usage
 
@@ -191,18 +193,18 @@ Install a specific version of Keycloak.
 
 ```puppet
 class { 'keycloak':
-  version => '22.0.0',
+  version => '24.0.0',
   db      => 'mariadb',
 }
 ```
 
 Upgrading Keycloak version works by changing `version` parameter as long as the `db` parameter is not the default of `dev-file`. An upgrade involves installing the new version without touching the old version, updating the symlink which defaults to `/opt/keycloak`, applying all changes to new version and then restarting the `keycloak` service.
 
-If the previous `version` was `22.0.0` using the following will upgrade to `23.0.0`:
+If the previous `version` was `22.0.0` using the following will upgrade to `24.0.0`:
 
 ```puppet
 class { 'keycloak':
-  version => '23.0.0',
+  version => '24.0.0',
   db      => 'mariadb',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This module may work on earlier versions but this is the only version tested.
 | 19.x - 21.x      | 9.x                             |
 | 21.x             | 10.x                            |
 | 22.x - 24.x      | 11.x                            |
-| 24.x - 25.x      | 12.x                            |
+| 24.x             | 12.x                            |
 | -----------------|---------------------------------|
 
 ## Usage

--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -488,6 +488,11 @@ Manage Keycloak realms
     defaultto []
   end
 
+  newproperty(:web_authn_policy_extra_origins, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
+    desc 'webAuthnPolicyExtraOrigins'
+    defaultto []
+  end
+
   newproperty(:web_authn_policy_passwordless_rp_entity_name) do
     desc 'webAuthnPolicyPasswordlessRpEntityName'
     defaultto 'keycloak'
@@ -540,6 +545,11 @@ Manage Keycloak realms
 
   newproperty(:web_authn_policy_passwordless_acceptable_aaguids, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
     desc 'webAuthnPolicyPasswordlessAcceptableAaguids'
+    defaultto []
+  end
+
+  newproperty(:web_authn_policy_passwordless_extra_origins, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
+    desc 'webAuthnPolicyPasswordlessExtraOrigins'
     defaultto []
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -222,7 +222,7 @@
 #   Only necessary to set if the URL path to Keycloak is modified
 class keycloak (
   Boolean $manage_install       = true,
-  String $version               = '22.0.0',
+  String $version               = '24.0.5',
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl, Stdlib::Absolutepath]] $package_url= undef,
   Optional[Stdlib::Absolutepath] $install_dir = undef,
   Array[String[1]] $java_package_dependencies = [],

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -239,6 +239,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         web_authn_policy_create_timeout                    => 600,
         web_authn_policy_avoid_same_authenticator_register => true,
         web_authn_policy_acceptable_aaguids                => ['d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1'],
+        web_authn_policy_extra_origins                     => ['https://example.com'],
         web_authn_policy_passwordless_rp_entity_name                    => 'Keycloak',
         web_authn_policy_passwordless_signature_algorithms              => ['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512'],
         web_authn_policy_passwordless_rp_id                             => 'https://example.com',
@@ -249,6 +250,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         web_authn_policy_passwordless_create_timeout                    => 600,
         web_authn_policy_passwordless_avoid_same_authenticator_register => true,
         web_authn_policy_passwordless_acceptable_aaguids                => ['d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1'],
+        web_authn_policy_passwordless_extra_origins                     => ['https://example.com'],
       }
       PUPPET_PP
 
@@ -321,6 +323,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['webAuthnPolicyCreateTimeout']).to eq(600)
         expect(data['webAuthnPolicyAvoidSameAuthenticatorRegister']).to eq(true)
         expect(data['webAuthnPolicyAcceptableAaguids']).to eq(['d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1'])
+        expect(data['webAuthnPolicyExtraOrigins']).to eq(['https://example.com'])
         expect(data['webAuthnPolicyPasswordlessRpEntityName']).to eq('Keycloak')
         expect(data['webAuthnPolicyPasswordlessSignatureAlgorithms']).to eq(['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512'])
         expect(data['webAuthnPolicyPasswordlessRpId']).to eq('https://example.com')
@@ -331,6 +334,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['webAuthnPolicyPasswordlessCreateTimeout']).to eq(600)
         expect(data['webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister']).to eq(true)
         expect(data['webAuthnPolicyPasswordlessAcceptableAaguids']).to eq(['d1d1d1d1-d1d1-d1d1-d1d1-d1d1d1d1d1d1'])
+        expect(data['webAuthnPolicyPasswordlessExtraOrigins']).to eq(['https://example.com'])
       end
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,7 @@ describe 'keycloak' do
       let(:facts) do
         facts.merge(concat_basedir: '/dne')
       end
-      let(:version) { '22.0.0' }
+      let(:version) { '24.0.5' }
 
       case facts[:osfamily]
       when %r{RedHat}

--- a/spec/defines/partial_import_spec.rb
+++ b/spec/defines/partial_import_spec.rb
@@ -8,7 +8,7 @@ describe 'keycloak::partial_import' do
       let(:facts) do
         facts.merge(concat_basedir: '/dne')
       end
-      let(:version) { '22.0.0' }
+      let(:version) { '24.0.5' }
       let(:title) { 'test' }
       let(:params) do
         {

--- a/spec/defines/spi_deployment_spec.rb
+++ b/spec/defines/spi_deployment_spec.rb
@@ -8,7 +8,7 @@ describe 'keycloak::spi_deployment' do
       let(:facts) do
         facts.merge(concat_basedir: '/dne')
       end
-      let(:version) { '22.0.0' }
+      let(:version) { '24.0.5' }
       let(:title) { 'duo-spi' }
       let(:params) { { deployed_name: 'keycloak-duo-spi-jar-with-dependencies.jar', source: 'https://example.com/files/keycloak-duo-spi-jar-with-dependencies.jar' } }
 

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |c|
   c.add_setting :keycloak_version
   keycloak_version = if ENV['BEAKER_keycloak_version'].nil? || ENV['BEAKER_keycloak_version'].empty?
-                       '22.0.0'
+                       '24.0.5'
                      else
                        ENV['BEAKER_keycloak_version']
                      end

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -82,6 +82,7 @@ describe Puppet::Type.type(:keycloak_realm) do
     web_authn_policy_create_timeout: 0,
     web_authn_policy_avoid_same_authenticator_register: :false,
     web_authn_policy_acceptable_aaguids: [],
+    web_authn_policy_extra_origins: [],
     web_authn_policy_passwordless_rp_entity_name: 'keycloak',
     web_authn_policy_passwordless_signature_algorithms: ['ES256'],
     web_authn_policy_passwordless_rp_id: '',
@@ -91,7 +92,8 @@ describe Puppet::Type.type(:keycloak_realm) do
     web_authn_policy_passwordless_user_verification_requirement: 'not specified',
     web_authn_policy_passwordless_create_timeout: 0,
     web_authn_policy_passwordless_avoid_same_authenticator_register: :false,
-    web_authn_policy_passwordless_acceptable_aaguids: []
+    web_authn_policy_passwordless_acceptable_aaguids: [],
+    web_authn_policy_passwordless_extra_origins: []
   }
 
   describe 'otp_policy_digits' do
@@ -348,8 +350,10 @@ describe Puppet::Type.type(:keycloak_realm) do
       :roles,
       :web_authn_policy_signature_algorithms,
       :web_authn_policy_acceptable_aaguids,
+      :web_authn_policy_extra_origins,
       :web_authn_policy_passwordless_signature_algorithms,
-      :web_authn_policy_passwordless_acceptable_aaguids
+      :web_authn_policy_passwordless_acceptable_aaguids,
+      :web_authn_policy_passwordless_extra_origins
     ].each do |p|
       it "accepts array for #{p}" do
         config[p] = ['foo', 'bar']


### PR DESCRIPTION
https://github.com/treydock/puppet-module-keycloak/pull/312 implements quiet a few properties on the realm resource.

The webauthn & webauthn passwordless extra origins property require at least KeyCloak 23.0.0 as it was added with that release.

This PR raises the minimum KeyCloak version used for acceptance testing and will add these properties.