### PR TITLE
Implement password policy property

### DIFF
--- a/lib/puppet/type/keycloak_realm.rb
+++ b/lib/puppet/type/keycloak_realm.rb
@@ -420,6 +420,10 @@ Manage Keycloak realms
     defaultto :false
   end
 
+  newproperty(:password_policy) do
+    desc 'passwordPolicy'
+  end
+
   newproperty(:roles, array_matching: :all, parent: PuppetX::Keycloak::ArrayProperty) do
     desc 'roles'
     defaultto ['offline_access', 'uma_authorization']

--- a/spec/acceptance/2_realm_spec.rb
+++ b/spec/acceptance/2_realm_spec.rb
@@ -229,6 +229,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         otp_policy_digits                 => 8,
         otp_policy_period                 => 30,
         otp_policy_code_reusable          => true,
+        password_policy                   => 'length(12) and notUsername(undefined) and notEmail(undefined) and forceExpiredPasswordChange(365) and hashIterations(27500) and passwordHistory(3) and specialChars(1) and upperCase(1) and lowerCase(1) and digits(1) and maxLength(64)',
         web_authn_policy_rp_entity_name                    => 'Keycloak',
         web_authn_policy_signature_algorithms              => ['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512'],
         web_authn_policy_rp_id                             => 'https://example.com',
@@ -258,6 +259,20 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
 
     it 'has updated the realm' do
       on hosts, '/opt/keycloak/bin/kcadm-wrapper.sh get realms/test' do
+        password_policy_value = [
+          'length(12)',
+          'notUsername(undefined)',
+          'notEmail(undefined)',
+          'forceExpiredPasswordChange(365)',
+          'hashIterations(27500)',
+          'passwordHistory(3)',
+          'specialChars(1)',
+          'upperCase(1)',
+          'lowerCase(1)',
+          'digits(1)',
+          'maxLength(64)'
+        ]
+
         data = JSON.parse(stdout)
         expect(data['rememberMe']).to eq(true)
         expect(data['registrationAllowed']).to eq(true)
@@ -311,6 +326,7 @@ describe 'keycloak_realm:', if: RSpec.configuration.keycloak_full do
         expect(data['otpPolicyDigits']).to eq(8)
         expect(data['otpPolicyPeriod']).to eq(30)
         expect(data['otpPolicyCodeReusable']).to eq(true)
+        expect(data['passwordPolicy']).to eq(password_policy_value.join(' and '))
         expect(data['webAuthnPolicyRpEntityName']).to eq('Keycloak')
         expect(data['webAuthnPolicySignatureAlgorithms']).to eq(['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512'])
         expect(data['webAuthnPolicyRpId']).to eq('https://example.com')

--- a/spec/unit/puppet/type/keycloak_realm_spec.rb
+++ b/spec/unit/puppet/type/keycloak_realm_spec.rb
@@ -219,6 +219,7 @@ describe Puppet::Type.type(:keycloak_realm) do
       :smtp_server_reply_to,
       :smtp_server_reply_to_display_name,
       :default_locale,
+      :password_policy,
       :web_authn_policy_rp_entity_name,
       :web_authn_policy_rp_id,
       :web_authn_policy_passwordless_rp_entity_name,


### PR DESCRIPTION
A simple implementation of the password policy property on realms.

It would enable us to configure password policy on our keycloak installations. 

Is it a good enough implementation or would you like to have some kind of seperate properties which get then send as `passwordPolicy` property to keycloak api?
It's kind of strange implementation on keycloak side that they don't expose the options seperatly instead they use some string with `and` to combine rules.