### PR TITLE
Client scope / Include in token scope attribute

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1943,6 +1943,14 @@ display.on.consent.screen
 
 Default value: `true`
 
+##### `include_in_token_scope`
+
+Valid values: ``true``, ``false``
+
+include.in.token.scope
+
+Default value: `true`
+
 ##### `ensure`
 
 Valid values: `present`, `absent`

--- a/lib/puppet/provider/keycloak_client_scope/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client_scope/kcadm.rb
@@ -30,6 +30,7 @@ Puppet::Type.type(:keycloak_client_scope).provide(:kcadm, parent: Puppet::Provid
         attributes = d['attributes'] || {}
         client_scope[:consent_screen_text] = attributes['consent.screen.text']
         client_scope[:display_on_consent_screen] = attributes['display.on.consent.screen']
+        client_scope[:include_in_token_scope] = attributes['include.in.token.scope']
         client_scopes << new(client_scope)
       end
     end
@@ -56,6 +57,7 @@ Puppet::Type.type(:keycloak_client_scope).provide(:kcadm, parent: Puppet::Provid
     attributes = {}
     attributes['consent.screen.text'] = resource[:consent_screen_text]
     attributes['display.on.consent.screen'] = resource[:display_on_consent_screen]
+    attributes['include.in.token.scope'] = resource[:include_in_token_scope]
     data[:attributes] = attributes
 
     t = Tempfile.new('keycloak_client_scope')
@@ -107,6 +109,7 @@ Puppet::Type.type(:keycloak_client_scope).provide(:kcadm, parent: Puppet::Provid
       attributes = {}
       attributes['consent.screen.text'] = @property_flush[:consent_screen_text] if @property_flush[:consent_screen_text]
       attributes['display.on.consent.screen'] = @property_flush[:display_on_consent_screen] if @property_flush[:display_on_consent_screen]
+      attributes['include.in.token.scope'] = @property_flush[:include_in_token_scope] if @property_flush[:include_in_token_scope]
       data[:attributes] = attributes if attributes
 
       t = Tempfile.new('keycloak_client_scope')

--- a/lib/puppet/type/keycloak_client_scope.rb
+++ b/lib/puppet/type/keycloak_client_scope.rb
@@ -59,7 +59,6 @@ Manage Keycloak client scopes
   newproperty(:include_in_token_scope, boolean: true) do
     desc 'include.in.token.scope'
     newvalues(:true, :false)
-    defaultto :true
   end
 
   def self.title_patterns

--- a/lib/puppet/type/keycloak_client_scope.rb
+++ b/lib/puppet/type/keycloak_client_scope.rb
@@ -56,6 +56,12 @@ Manage Keycloak client scopes
     defaultto :true
   end
 
+  newproperty(:include_in_token_scope, boolean: true) do
+    desc 'include.in.token.scope'
+    newvalues(:true, :false)
+    defaultto :true
+  end
+
   def self.title_patterns
     [
       [

--- a/spec/unit/puppet/type/keycloak_client_scope_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_scope_spec.rb
@@ -72,7 +72,8 @@ describe Puppet::Type.type(:keycloak_client_scope) do
 
   # Test boolean properties
   [
-    :display_on_consent_screen
+    :display_on_consent_screen,
+    :include_in_token_scope
   ].each do |p|
     it "accepts true for #{p}" do
       config[p] = true


### PR DESCRIPTION
We have additional updates, please, consider merging.

In this PR we add include.in.token.scope attribute of client scope.

Thank you.

Regards,
Robert.