### PR TITLE
Add Feature to set PKCE Code Challenge Method

### DIFF
--- a/lib/puppet/provider/keycloak_client/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client/kcadm.rb
@@ -22,6 +22,7 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
       :saml_signing_certificate,
       :saml_encryption_certificate,
       :saml_signing_private_key,
+      :pkce_code_challenge_method,
     ]
   end
 
@@ -35,6 +36,7 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
       :saml_signing_certificate,
       :saml_encryption_certificate,
       :saml_signing_private_key,
+      :pkce_code_challenge_method,
     ]
   end
 

--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -245,6 +245,12 @@ Manage Keycloak clients
     defaultto []
   end
 
+  newproperty(:pkce_code_challenge_method) do
+    desc 'PKCE Code Challenge Method for OAuth 2.0 flows'
+    newvalues('S256', 'plain', :absent)
+    defaultto :absent
+  end
+
   autorequire(:keycloak_client_scope) do
     requires = []
     catalog.resources.each do |resource|


### PR DESCRIPTION
This adds the feature to specify the PKCE Code Challenge Method.
It will be absent to not change any clients, but should set to S256 for maximum security.

This is also recommended by Oauth best practices and will be the main recommendation in Oauth 2.1