### PR TITLE
feat: adding support for attributes in keycloak_client

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1569,6 +1569,10 @@ access.token.lifespan
 
 adminUrl
 
+##### `attributes`
+
+Keycloak client attributes map as described by ClientRepresentation attributes
+
 ##### `authorization_services_enabled`
 
 Valid values: `true`, `false`

--- a/lib/puppet/provider/keycloak_client/kcadm.rb
+++ b/lib/puppet/provider/keycloak_client/kcadm.rb
@@ -125,7 +125,9 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
           key = property.to_s
           attributes = d['attributes'] || {}
           auth_flows = d['authenticationFlowBindingOverrides'] || {}
-          if property == :secret
+          if property == :attributes
+            value = attributes
+          elsif property == :secret
             value = secret
           elsif d.key?(camel_key)
             value = d[camel_key]
@@ -220,15 +222,15 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
       value = convert_property_value(resource[property.to_sym])
       next if value == 'absent' || value == :absent || value.nil?
 
-      if attributes_properties.include?(property)
-        unless data.key?(:attributes)
-          data[:attributes] = {}
-        end
+      if property == :attributes
+        data[:attributes] ||= {}
+        data[:attributes].merge!(value)
+        next
+      elsif attributes_properties.include?(property)
+        data[:attributes] ||= {}
         data[:attributes][attribute_key(property)] = value
       elsif auth_flow_properties.include?(property)
-        unless data.key?(:authenticationFlowBindingOverrides)
-          data[:authenticationFlowBindingOverrides] = {}
-        end
+        data[:authenticationFlowBindingOverrides] ||= {}
         flow_id = flow_ids[value]
         data[:authenticationFlowBindingOverrides][auth_flow_properties[property]] = flow_id
       else
@@ -371,10 +373,11 @@ Puppet::Type.type(:keycloak_client).provide(:kcadm, parent: Puppet::Provider::Ke
 
         value = convert_property_value(@property_flush[property.to_sym])
         value = nil if value.to_s == 'absent'
-        if attributes_properties.include?(property)
-          unless data.key?(:attributes)
-            data[:attributes] = {}
-          end
+        if property == :attributes
+          data[:attributes] ||= {}
+          data[:attributes].merge!(value)
+        elsif attributes_properties.include?(property)
+          data[:attributes] ||= {}
           data[:attributes][attribute_key(property)] = value
         elsif auth_flow_properties.include?(property)
           flow_id = value.nil? ? nil : flow_ids[value]

--- a/lib/puppet/type/keycloak_client.rb
+++ b/lib/puppet/type/keycloak_client.rb
@@ -229,6 +229,49 @@ Manage Keycloak clients
     desc 'webOrigins'
   end
 
+  newproperty(:attributes) do
+    desc 'Keycloak client attributes map as described by ClientRepresentation attributes'
+
+    defaultto {}
+
+    validate do |value|
+      # rubocop:disable Style/SignalException
+      fail 'custom_properties should be a Hash' unless value.is_a? ::Hash
+
+      value.each_pair do |_k, v|
+        fail 'custom_properties does not allow Hash values' if v.is_a? ::Hash
+      end
+      # rubocop:enable Style/SignalException
+    end
+
+    def insync?(is)
+      should = @should
+      should = should[0] if should.is_a?(Array)
+      should.each_pair do |k, v|
+        return false unless is.key?(k)
+
+        case v
+        when String, TrueClass, FalseClass
+          return false if is[k].to_s != v.to_s
+        when Array
+          return false if is[k].sort != v.sort
+        end
+      end
+      true
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      currentvalue = currentvalue.to_s if currentvalue != :absent
+      newvalue = newvalue.to_s
+      super(currentvalue, newvalue)
+    end
+
+    def is_to_s(currentvalue) # rubocop:disable Style/PredicateName
+      currentvalue.to_s
+    end
+    alias_method :should_to_s, :is_to_s
+  end
+
   newproperty(:login_theme) do
     desc 'login_theme'
     defaultto :absent

--- a/spec/acceptance/5_client_spec.rb
+++ b/spec/acceptance/5_client_spec.rb
@@ -15,6 +15,7 @@ describe 'keycloak_client define:', if: RSpec.configuration.keycloak_full_batch1
         redirect_uris                            => ['https://test.foo.bar/test1'],
         default_client_scopes                    => ['address'],
         secret                                   => 'foobar',
+        attributes                               => { 'foo' => 'bar' },
         login_theme                              => 'keycloak',
         backchannel_logout_url                   => 'https://test.foo.bar/logout',
         backchannel_logout_session_required      => 'true',
@@ -75,6 +76,7 @@ describe 'keycloak_client define:', if: RSpec.configuration.keycloak_full_batch1
         expect(data['authorizationServicesEnabled']).to eq(nil)
         expect(data['serviceAccountsEnabled']).to eq(true)
         expect(data['authenticationFlowBindingOverrides']['browser']).to eq('foo-test')
+        expect(data['attributes']['foo']).to eq('bar')
         expect(data['attributes']['backchannel.logout.url']).to eq('https://test.foo.bar/logout')
         expect(data['attributes']['backchannel.logout.session.required']).to eq('true')
         expect(data['attributes']['backchannel.logout.revoke.offline.tokens']).to eq('true')

--- a/spec/unit/puppet/type/keycloak_client_spec.rb
+++ b/spec/unit/puppet/type/keycloak_client_spec.rb
@@ -184,6 +184,23 @@ describe Puppet::Type.type(:keycloak_client) do
     end
   end
 
+  describe 'attributes' do
+    it 'allow attributes' do
+      config[:attributes] = { 'foo' => 'bar' }
+      expect(resource[:attributes]).to eq('foo' => 'bar')
+    end
+
+    it 'is in sync with default' do
+      config[:attributes] = {}
+      expect(resource.property(:attributes).insync?('foo' => 'bar')).to eq(true)
+    end
+
+    it 'is in sync with defined properties' do
+      config[:attributes] = { 'foo' => 'bar' }
+      expect(resource.property(:attributes).insync?('foo' => 'bar', 'bar' => 'baz')).to eq(true)
+    end
+  end
+
   it 'autorequires keycloak_conn_validator' do
     keycloak_conn_validator = Puppet::Type.type(:keycloak_conn_validator).new(name: 'keycloak')
     catalog = Puppet::Resource::Catalog.new


### PR DESCRIPTION
This allows to set the attributes inside the keycloak_client, e.g. additional authentication mechanisms like oauth2 device authorization.

```json
  "attributes": {
    "realm_client": "false",
    "oidc.ciba.grant.enabled": "false",
    "backchannel.logout.session.required": "true",
    "standard.token.exchange.enabled": "false",
    "display.on.consent.screen": "false",
    "oauth2.device.authorization.grant.enabled": "true",
    "backchannel.logout.revoke.offline.tokens": "false"
  },

```