### PR TITLE
Add Ubuntu 26.04 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -12,6 +12,7 @@ Rakefile:
       - debian-12
       - ubuntu-2204
       - ubuntu-2404
+      - ubuntu-2604
     puppet:
       - puppet8
     keycloak_version:
@@ -52,5 +53,8 @@ spec/acceptance/nodesets/ubuntu-2204.yml:
   packages:
     - iproute2
 spec/acceptance/nodesets/ubuntu-2404.yml:
+  packages:
+    - iproute2
+spec/acceptance/nodesets/ubuntu-2604.yml:
   packages:
     - iproute2

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ This module has been tested on:
 * Debian 12 x86_64
 * Ubuntu 22.04 x86_64
 * Ubuntu 24.04 x86_64
+* Ubuntu 26.04 x86_64
 
 ## UUID Generation
 

--- a/data/os/Ubuntu/26.04.yaml
+++ b/data/os/Ubuntu/26.04.yaml
@@ -1,0 +1,4 @@
+# TODO: Use until the defaults are addressed upstream:
+# https://github.com/puppetlabs/puppetlabs-mysql/issues/1507
+keycloak::db_charset: utf8mb3
+keycloak::db_collate: utf8mb3_general_ci

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "22.04",
-        "24.04"
+        "24.04",
+        "26.04"
       ]
     }
   ],

--- a/spec/acceptance/nodesets/ubuntu-2604.yml
+++ b/spec/acceptance/nodesets/ubuntu-2604.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu2604:
+    roles:
+      - agent
+    platform: ubuntu-26.04-amd64
+    hypervisor : docker
+    image: ubuntu:26.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
+      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'keycloak-ubuntu2604'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]


### PR DESCRIPTION
Adds Ubuntu 26.04 LTS to `operatingsystem_support`.

We run this module (v14.2.0) on Ubuntu 26.04 hosts with Keycloak 26.x in production without issues — the manifests contain no OS-release-specific branches for Ubuntu, so metadata is the only change needed. Java comes in via the `java` class (OpenJDK 21 on 26.04), which resolves fine.

Happy to add an acceptance nodeset for 26.04 in a follow-up once container images for it are common in your CI setup.